### PR TITLE
docs: TaiwanStockPriceLimit 說明 0 表示無漲跌幅限制

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -252,6 +252,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - Params: dataset=TaiwanStockPriceLimit, data_id=2330, start_date=2023-01-01
 - Params (all stocks, Backer/Sponsor): dataset=TaiwanStockPriceLimit, start_date=2023-01-01 (不帶 data_id，取得該日所有股票資料)
 - Columns: date (str), stock_id (str), reference_price (float64), limit_up (float64), limit_down (float64)
+- Note: limit_up/limit_down 為 0 表示無漲跌幅限制（槓桿型 ETF 如 00631L、反向型 ETF 如 00632R、興櫃股票）
 
 ---
 

--- a/docs/tutor/TaiwanMarket/Technical.md
+++ b/docs/tutor/TaiwanMarket/Technical.md
@@ -2370,10 +2370,17 @@
             date: str, # 日期
             stock_id: str, # 股票代碼
             reference_price: float64, # 參考價
-            limit_up: float64, # 漲停價
-            limit_down: float64 # 跌停價
+            limit_up: float64, # 漲停價（0 表示無漲跌幅限制）
+            limit_down: float64 # 跌停價（0 表示無漲跌幅限制）
         }
         ```
+
+!!! note
+    `limit_up` 和 `limit_down` 為 **0** 時，表示該標的無漲跌幅限制，包含：
+
+    - 槓桿型 ETF（如 00631L）
+    - 反向型 ETF（如 00632R）
+    - 興櫃股票
 
 #### 一次拿特定日期，所有資料(只限 [backer、sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) 會員使用)
 


### PR DESCRIPTION
槓桿型 ETF、反向型 ETF、興櫃股票的 limit_up/limit_down 為 0