### PR TITLE
docs: llms.txt / llms-full.txt 補上 TaiwanStockBlockTrade 與 TaiwanStock…

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -376,6 +376,20 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - Params: dataset=TaiwanStockBlockTradingDailyReport, start_date=2026-04-28
 - Columns: securities_trader, price, buy, sell, trade_type, securities_trader_id, stock_id, date
 
+### TaiwanStockBlockTrade (鉅額交易日成交資訊)
+- Tier: Sponsor
+- Data range: 2005-04-04 ~ now
+- Params: dataset=TaiwanStockBlockTrade, data_id=2330, start_date=2026-04-01, end_date=2026-04-30
+- Params (all stocks for one day): dataset=TaiwanStockBlockTrade, start_date=2026-04-24, end_date=2026-04-24
+- Columns: date, stock_id, trade_type, price, volume, trading_money
+
+### TaiwanStockLoanCollateralBalance (借貸款項擔保品餘額表)
+- Tier: Sponsor
+- Data range: 2006-10-02 ~ now
+- Params: dataset=TaiwanStockLoanCollateralBalance, data_id=2330, start_date=2025-01-02, end_date=2025-01-31
+- Params (all stocks for one day): dataset=TaiwanStockLoanCollateralBalance, start_date=2025-01-02
+- Columns: date, stock_id, market, MarginPreviousDayBalance, MarginBuy, MarginSell, MarginCashRedemption, MarginCurrentDayBalance, MarginNextDayQuota, SecuritiesFirmLoanPreviousDayBalance, SecuritiesFirmLoanBuy, SecuritiesFirmLoanSell, SecuritiesFirmLoanCashRedemption, SecuritiesFirmLoanReplacement, SecuritiesFirmLoanCurrentDayBalance, SecuritiesFirmLoanNextDayQuota, UnrestrictedLoanPreviousDayBalance, UnrestrictedLoanBuy, UnrestrictedLoanSell, UnrestrictedLoanCashRedemption, UnrestrictedLoanReplacement, UnrestrictedLoanCurrentDayBalance, UnrestrictedLoanNextDayQuota, SecuritiesFinanceSecuredLoanPreviousDayBalance, SecuritiesFinanceSecuredLoanBuy, SecuritiesFinanceSecuredLoanSell, SecuritiesFinanceSecuredLoanCashRedemption, SecuritiesFinanceSecuredLoanReplacement, SecuritiesFinanceSecuredLoanCurrentDayBalance, SecuritiesFinanceSecuredLoanNextDayQuota, SettlementMarginPreviousDayBalance, SettlementMarginBuy, SettlementMarginSell, SettlementMarginCashRedemption, SettlementMarginReplacement, SettlementMarginCurrentDayBalance, SettlementMarginNextDayQuota
+
 ### TaiwanStockDispositionSecuritiesPeriod (公布處置有價證券表)
 - Tier: Backer/Sponsor
 - Data range: 2001-01-01 ~ now

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -46,11 +46,11 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - [Login](https://finmind.github.io/login/): Authentication methods
 - [API Usage Count](https://finmind.github.io/api_usage_count/): Check API usage via `GET https://api.web.finmindtrade.com/v2/user_info` (Authorization: Bearer {token}). Returns `user_count` (current usage) and `api_request_limit` (quota). HTTP 402 when quota exceeded.
 
-### Taiwan Market (75 datasets)
+### Taiwan Market (77 datasets)
 
-- [Taiwan DataList](https://finmind.github.io/tutor/TaiwanMarket/DataList/): Full list of 76 Taiwan datasets
+- [Taiwan DataList](https://finmind.github.io/tutor/TaiwanMarket/DataList/): Full list of 78 Taiwan datasets
 - [Technical](https://finmind.github.io/tutor/TaiwanMarket/Technical/): TaiwanStockInfo, TaiwanStockPrice, TaiwanStockPriceAdj, TaiwanStockPriceTick, TaiwanStockPER, TaiwanStockKBar, TaiwanStockWeekPrice, TaiwanStockMonthPrice, TaiwanStockDayTrading, TaiwanStockTotalReturnIndex, TaiwanVariousIndicators5Seconds, TaiwanStockTradingDate, etc.
-- [Chip (Institutional)](https://finmind.github.io/tutor/TaiwanMarket/Chip/): TaiwanStockMarginPurchaseShortSale, TaiwanStockInstitutionalInvestorsBuySell, TaiwanStockShareholding, TaiwanStockHoldingSharesPer, TaiwanStockSecuritiesLending, TaiwanStockTradingDailyReport, TaiwanStockBlockTradingDailyReport, TaiwanstockGovernmentBankBuySell, etc.
+- [Chip (Institutional)](https://finmind.github.io/tutor/TaiwanMarket/Chip/): TaiwanStockMarginPurchaseShortSale, TaiwanStockInstitutionalInvestorsBuySell, TaiwanStockShareholding, TaiwanStockHoldingSharesPer, TaiwanStockSecuritiesLending, TaiwanStockTradingDailyReport, TaiwanStockBlockTradingDailyReport, TaiwanStockBlockTrade, TaiwanStockLoanCollateralBalance, TaiwanstockGovernmentBankBuySell, etc.
 - [Fundamental](https://finmind.github.io/tutor/TaiwanMarket/Fundamental/): TaiwanStockCashFlowsStatement, TaiwanStockFinancialStatements, TaiwanStockBalanceSheet, TaiwanStockDividend, TaiwanStockDividendResult, TaiwanStockMonthRevenue, TaiwanStockMarketValue, etc.
 - [Derivative](https://finmind.github.io/tutor/TaiwanMarket/Derivative/): TaiwanFuturesDaily, TaiwanOptionDaily, TaiwanFuturesTick, TaiwanOptionTIck, TaiwanFuturesInstitutionalInvestors, TaiwanOptionInstitutionalInvestors, TaiwanFuturesDealerTradingVolumeDaily, TaiwanOptionDealerTradingVolumeDaily, TaiwanFuturesSpreadTrading, etc.
 - [Real-Time](https://finmind.github.io/tutor/TaiwanMarket/RealTime/): taiwan_stock_tick_snapshot, TaiwanFutOptTickInfo, taiwan_futures_snapshot, taiwan_options_snapshot


### PR DESCRIPTION
…LoanCollateralBalance

兩個新 dataset 之前 Chip.md 教學頁已加，但 LLM-friendly 索引漏更新：

- llms-full.txt 新增兩段獨立 entry（與 BlockTradingDailyReport 區隔）：
  - TaiwanStockBlockTrade（鉅額交易日成交資訊，逐筆，2005-04-04 起）
  - TaiwanStockLoanCollateralBalance（借貸款項擔保品餘額表，37 欄位， 2006-10-02 起）
- llms.txt：
  - Taiwan Market dataset 數從 75 → 77、DataList 從 76 → 78
  - Chip 列表加入兩個新 dataset 名稱