### PR TITLE
docs: 新增「更新 Token」功能說明子頁面

### DIFF
--- a/docs/WhatIsNew.md
+++ b/docs/WhatIsNew.md
@@ -1,3 +1,6 @@
+#### 2026-05-02
+* 新增「[更新 Token](https://finmind.github.io/update_token/)」功能：可在使用者資訊頁面自主重置 Token，舊 Token 立即失效，無需聯繫客服
+
 #### 2026-04-30
 * 新增 [借貸款項擔保品餘額表 TaiwanStockLoanCollateralBalance](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockloancollateralbalance-sponsor)
 

--- a/docs/update_token.md
+++ b/docs/update_token.md
@@ -1,0 +1,19 @@
+# 更新 Token
+
+當您懷疑 Token 有外流風險時，可在[使用者資訊頁面](https://finmindtrade.com/analysis/#/account/user)自行更新 Token，無需聯繫客服。
+
+#### 操作方式
+
+1. 進入[使用者資訊頁面](https://finmindtrade.com/analysis/#/account/user)
+2. 在 `api token 金鑰` 欄位下方點選「更新 token」按鈕
+3. 確認後系統會立即產生新的 Token
+
+#### 功能說明
+
+- 一鍵產生新的 Token
+- 舊 Token 立即失效
+- 所有裝置會被登出，需重新登入取得新 Token
+- 無需聯繫客服，自主完成操作
+
+!!! tip
+    建議定期更新 Token，以確保使用安全。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,9 @@ extra:
 nav:
     - 總覽: 'index.md'
     - 快速開始: "quickstart.md"
-    - 登入: "login.md"
+    - 登入:
+        - 登入說明: "login.md"
+        - 更新 Token: "update_token.md"
     - API 使用次數: "api_usage_count.md"
     - 資料集:
         - 台灣市場:


### PR DESCRIPTION
## Summary
- 新增 `docs/update_token.md` 子頁面，說明使用者如何在使用者資訊頁面自主更新 Token（按鈕位置、操作步驟、舊 Token 立即失效、所有裝置會被登出等）
- `mkdocs.yml`：將 `登入` 改為含子選單（`登入說明` / `更新 Token`）
- `WhatIsNew.md` 補上 2026-05-02 條目，連結指向新子頁

## Test plan
- [ ] `mkdocs serve` 後側邊選單「登入」展開可看到「登入說明」「更新 Token」兩個子項
- [ ] `/update_token/` 頁面內容、連結（指向使用者資訊頁面）正確
- [ ] WhatIsNew 條目連結可跳到新子頁

🤖 Generated with [Claude Code](https://claude.com/claude-code)