### PR TITLE
docs(llms-full): TradingDailyReport 跟 SecIdAgg 改用專屬 endpoint，避免 AI agent 構造錯誤請求

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -336,10 +336,11 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - Tier: Sponsor
 - Data range: 2021-06-30 ~ now
 - Update: Mon-Fri 21:00
-- Params (by stock): dataset=TaiwanStockTradingDailyReport, data_id=2330, start_date=2022-06-16
-- Params (by broker): dataset=TaiwanStockTradingDailyReport, data_id=1102, start_date=2022-06-16
+- Endpoint: `GET https://api.finmindtrade.com/api/v4/taiwan_stock_trading_daily_report` (專屬 endpoint，不走 /api/v4/data)
+- Params (by stock): data_id=2330, date=2022-06-16
+- Params (by broker): securities_trader_id=1020, date=2022-06-16
 - Columns: securities_trader, price, buy, sell, securities_trader_id, stock_id, date
-- Note: Single day per request.
+- Note: Single day per request, only `date` (no start_date/end_date).
 
 ### TaiwanStockWarrantTradingDailyReport (台股權證分點資料表)
 - Tier: Sponsor
@@ -366,7 +367,8 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - Tier: Sponsor
 - Data range: 2021-06-30 ~ now
 - Update: Mon-Fri 21:00
-- Params: dataset=TaiwanStockTradingDailyReportSecIdAgg, data_id=2330, start_date=2024-07-01, end_date=2024-07-15
+- Endpoint: `GET https://api.finmindtrade.com/api/v4/taiwan_stock_trading_daily_report_secid_agg` (專屬 endpoint，不走 /api/v4/data)
+- Params: data_id=2330, start_date=2024-07-01, end_date=2024-07-15
 - Columns: securities_trader, securities_trader_id, stock_id, date, buy_volume, sell_volume, buy_price, sell_price
 
 ### TaiwanStockBlockTradingDailyReport (鉅額交易買賣日報表)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,11 +7,14 @@
 - Base URL: `https://api.finmindtrade.com/api/v4`
 - Authentication: Register at finmindtrade.com, get token via login API or website. Pass token as `Authorization: Bearer {token}` header.
 - Rate limit: 600 requests/hour (with token), 300/hour (without token).
-- Four endpoints:
+- Endpoints:
   - `POST /login` - Get auth token (params: user_id, password)
   - `GET /data` - Fetch dataset (params: dataset, data_id, start_date, end_date, token)
   - `GET /datalist` - List available data_id values for a dataset
   - `GET /translation` - Get English-Chinese column name mapping for a dataset
+  - Some heavy datasets have dedicated endpoints instead of `/data` — they will return 422 if queried via `/data?dataset=...`. See `llms-full.txt` for the exact endpoint of each dataset. Currently:
+    - `GET /taiwan_stock_trading_daily_report` (params: data_id or securities_trader_id, date) — TaiwanStockTradingDailyReport, single date per request
+    - `GET /taiwan_stock_trading_daily_report_secid_agg` (params: data_id, start_date, end_date) — TaiwanStockTradingDailyReportSecIdAgg
 
 ## Python SDK
 


### PR DESCRIPTION
## 問題
AI agent（Claude / ChatGPT / Cursor 等）會讀 \`docs/llms-full.txt\` 學 API 用法。

\`TaiwanStockTradingDailyReport\` 跟 \`TaiwanStockTradingDailyReportSecIdAgg\` 在文件原本寫成：
\`\`\`
- Params: dataset=TaiwanStockTradingDailyReport, data_id=2330, start_date=...
\`\`\`

AI 套這個範本構造 \`GET /api/v4/data?dataset=TaiwanStockTradingDailyReport&...\` → **/api/v4/data 不接受這兩個 dataset，一律 422**。

這兩個 dataset 必須走專屬 endpoint。

## 修法
| 條目 | 改動 |
|---|---|
| TaiwanStockTradingDailyReport | 加 \`Endpoint: GET /api/v4/taiwan_stock_trading_daily_report\` 行；params 改 \`data_id\` 或 \`securities_trader_id\` + \`date\`（單日） |
| TaiwanStockTradingDailyReportSecIdAgg | 加 \`Endpoint: GET /api/v4/taiwan_stock_trading_daily_report_secid_agg\` 行；params 改 \`data_id\` + \`start_date\` + \`end_date\`（沒有 dataset 欄位） |

兩條都加「不走 /api/v4/data」備註提醒 AI。

## 不修改
- 其它 dataset 條目（走 /api/v4/data 是對的）
- 使用者導向 doc（\`Chip.md\`、\`DataList.md\`、\`WhatIsNew.md\`）已示範專屬 endpoint，不需改
- \`llms.txt\`（只列 dataset 名單）
- \`site/\` 目錄（mkdocs build 產物，CI regen）

## 驗證
deploy 後（GitHub Pages 重 build），AI agent 重新抓 \`https://finmind.github.io/llms-full.txt\` 應該會生對的 request，422 量會逐步下降。