### PR TITLE
docs: TaiwanStockTradingDailyReport storage_objects 補上 Package 範例

### DIFF
--- a/docs/WhatIsNew.md
+++ b/docs/WhatIsNew.md
@@ -1,3 +1,6 @@
+#### 2026-05-06
+* [台股分點資料表 TaiwanStockTradingDailyReport](https://finmind.github.io/tutor/TaiwanMarket/Chip/) storage_objects 文件補上 FinMind package 範例 (`taiwan_stock_trading_daily_report(use_object=True)`)
+
 #### 2026-05-05
 * [台股分點資料表 TaiwanStockTradingDailyReport](https://finmind.github.io/tutor/TaiwanMarket/Chip/) 新增 storage_objects 一次取得整日資料的下載方式（只限 sponsorpro 會員）
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -156,6 +156,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - Params: dataset=TaiwanStockPriceTick, data_id=2330, start_date=2020-01-02
 - Columns: date (str), stock_id (str), deal_price (float64), volume (int64), Time (str), TickType (str: 0=unknown, 1=sell, 2=buy)
 - Note: Single day per request.
+- Bulk download (sponsorpro): `GET /api/v4/storage_objects?dataset=TaiwanStockPriceTick&date=2019-01-02` returns whole-day parquet via signed URL, ignores data_id. Python SDK: `api.taiwan_stock_tick(date='2019-01-02', use_object=True)`.
 
 ### TaiwanStockPER (個股 PER、PBR 資料表)
 - Tier: Free
@@ -341,6 +342,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - Params (by broker): securities_trader_id=1020, date=2022-06-16
 - Columns: securities_trader, price, buy, sell, securities_trader_id, stock_id, date
 - Note: Single day per request, only `date` (no start_date/end_date).
+- Bulk download (sponsorpro): `GET /api/v4/storage_objects?dataset=TaiwanStockTradingDailyReport&date=2022-06-16` returns whole-day parquet via signed URL, ignores data_id / securities_trader_id. Python SDK: `api.taiwan_stock_trading_daily_report(date='2022-06-16', use_object=True)`.
 
 ### TaiwanStockWarrantTradingDailyReport (台股權證分點資料表)
 - Tier: Sponsor

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,6 +15,7 @@
   - Some heavy datasets have dedicated endpoints instead of `/data` — they will return 422 if queried via `/data?dataset=...`. See `llms-full.txt` for the exact endpoint of each dataset. Currently:
     - `GET /taiwan_stock_trading_daily_report` (params: data_id or securities_trader_id, date) — TaiwanStockTradingDailyReport, single date per request
     - `GET /taiwan_stock_trading_daily_report_secid_agg` (params: data_id, start_date, end_date) — TaiwanStockTradingDailyReportSecIdAgg
+  - `GET /storage_objects` (params: dataset, date) — sponsorpro-tier whole-day parquet via signed URL, ignores data_id. Currently supports: TaiwanStockPriceTick, TaiwanStockTradingDailyReport.
 
 ## Python SDK
 

--- a/docs/tutor/TaiwanMarket/Chip.md
+++ b/docs/tutor/TaiwanMarket/Chip.md
@@ -1735,6 +1735,17 @@
 - 部分資料缺失，缺失日期為：2022-10-31~2022-11-03, 2023-01-11~2023-01-17
 
 !!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_trading_daily_report(
+            date='2022-06-16',
+            use_object=True,
+        )
+        ```
     === "Python-request"
         ```python
         import io


### PR DESCRIPTION
## Summary
sponsorpro 整日下載小節之前因 FinMind package 還沒支援 \`use_object\` 而只放 Python-request / R 範例。Package 端已支援，補上 Package tab：

\`\`\`python
from FinMind.data import DataLoader

api = DataLoader()
# api.login_by_token(api_token='token')
df = api.taiwan_stock_trading_daily_report(
    date='2022-06-16',
    use_object=True,
)
\`\`\`

WhatIsNew.md 加 2026-05-06 條目。

## Test plan
- [ ] mkdocs build 通過
- [ ] 預覽 Chip.md 該章節 Package / Python-request / R 三個 tab 切換正常
- [ ] WhatIsNew.md 連結有效

🤖 Generated with [Claude Code](https://claude.com/claude-code)