### PR TITLE
docs(agent-skill): 補上 Codex 安裝範例

### DIFF
--- a/docs/tutor/AgentSkill.md
+++ b/docs/tutor/AgentSkill.md
@@ -1,4 +1,4 @@
-FinMind 提供 AI Agent Skill，讓你可以在 [Gemini](https://gemini.google.com/)、[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)、[Cursor](https://www.cursor.com/)、[Windsurf](https://windsurf.com/) 等 AI 工具中，透過自然語言查詢 FinMind 75+ 種資料集，不需要自己組 API 參數。
+FinMind 提供 AI Agent Skill，讓你可以在 [Gemini](https://gemini.google.com/)、[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)、[Codex](https://github.com/openai/codex)、[Cursor](https://www.cursor.com/)、[Windsurf](https://windsurf.com/) 等 AI 工具中，透過自然語言查詢 FinMind 75+ 種資料集，不需要自己組 API 參數。
 
 ## 安裝
 
@@ -9,6 +9,10 @@ FinMind 提供 AI Agent Skill，讓你可以在 [Gemini](https://gemini.google.c
         ```bash
         mkdir -p ~/.claude/commands
         curl -o ~/.claude/commands/finmind.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Codex"
+        ```bash
+        curl -o AGENTS.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
         ```
     === "Cursor"
         ```bash


### PR DESCRIPTION
## Summary
- 在 AgentSkill 教學頁面新增 Codex 的安裝 tab，指引使用者下載到 `AGENTS.md`
- 介紹文字加入 Codex 連結，與既有的 Gemini / Claude Code / Cursor / Windsurf 並列

## Test plan
- [ ] 本地預覽 docs 頁面，確認 Codex tab 正常顯示
- [ ] 確認 curl URL 連結可下載

🤖 Generated with [Claude Code](https://claude.com/claude-code)