### PR TITLE
docs: 新增英文版完整翻譯與雙語站設定

### DIFF
--- a/docs/BanIPPolicy.en.md
+++ b/docs/BanIPPolicy.en.md
@@ -1,0 +1,78 @@
+# IP Ban Policy
+
+To keep the service stable and protect legitimate users, the FinMind API automatically and temporarily blocks IPs that **generate a large number of error requests in a short period**.
+
+## Trigger conditions
+
+A burst of 4xx requests from one IP (e.g., invalid token, malformed token, bad parameters, quota exceeded) will trigger an automatic block.
+
+Normal users almost never trigger this. Typical triggers come from:
+
+- Crawler scripts hammering with an expired or invalid token
+- Code that doesn't handle API errors and keeps retrying with the same broken request
+- Malicious attempts to brute-force tokens or abuse the service
+
+## API response while blocked
+
+While blocked, every API request returns:
+
+**Status code**: `403 Forbidden`
+
+**Response body**:
+```json
+{"msg": "ip banned", "status": 403}
+```
+
+!!! example
+    === "Python"
+        ```python
+        import requests
+        url = "https://api.finmindtrade.com/api/v4/data"
+        resp = requests.get(url, params={"dataset": "TaiwanStockPrice"})
+        print(resp.status_code)
+        print(resp.json())
+        ```
+
+    === "resp.status_code"
+        ```
+        403
+        ```
+    === "resp.json()"
+        ```python
+        {"msg": "ip banned", "status": 403}
+        ```
+
+## Block duration
+
+Blocked IPs are **automatically released after 30 minutes**, no manual action required. If invalid requests continue after release, the IP will be blocked again.
+
+## How to avoid being blocked
+
+1. **Token management**
+
+    - On `TokenIllegal` (400) or `TokenLevelTooLow`, the token is invalid or under-permissioned — **stop retrying with that token**
+    - Sign in again via [Login](login.md) to obtain a fresh token before retrying
+
+2. **Error handling**
+
+    - 4xx usually means the request itself is wrong (parameters, dates, dataset name, data id, etc.). Fix the parameters before resending — **do not retry forever**
+    - 5xx can be retried with exponential backoff, but cap the retry count
+
+3. **Request rate**
+
+    - See [Stress Test](StressTest.md) for the recommended request rate
+    - Exceeding your tier's quota returns `402` — upgrade or wait for the next billing cycle. See [API Usage Count](api_usage_count.md)
+
+4. **Use the correct endpoint and parameters**
+
+    - Send requests using the endpoints and parameter formats shown in [Quick Start](quickstart.md)
+
+## Appeal a wrongful block
+
+If you are a legitimate user and believe you were blocked by mistake, email us with the following so we can help unblock quickly:
+
+- Your source IP (look it up at <https://ifconfig.me>)
+- The token or registered email you were using
+- When and how it happened
+
+📧 Contact: <finmind.tw@gmail.com>

--- a/docs/Contact.en.md
+++ b/docs/Contact.en.md
@@ -1,0 +1,6 @@
+
+
+## Chat: [Facebook Group](https://www.facebook.com/groups/401634838071226)
+## Page: [FinMind](https://www.facebook.com/profile.php?id=100065614368124)
+## Issue: [GitHub](https://github.com/FinMind/FinMind)
+## Other: FinMind.TW@gmail.com

--- a/docs/Donate.en.md
+++ b/docs/Donate.en.md
@@ -1,0 +1,6 @@
+
+## [Sponsor us to develop more features (you decide the amount)](https://p.ecpay.com.tw/8196A98)
+
+
+<a href="https://p.ecpay.com.tw/8196A98"><img src="https://payment.ecpay.com.tw/Content/themes/WebStyle20170517/images/ecgo.png" alt=""/></a>
+

--- a/docs/License.en.md
+++ b/docs/License.en.md
@@ -1,0 +1,4 @@
+
+
+## [License](https://github.com/linsamtw/FinMind/blob/master/LICENSE)
+## All content provided here is for educational use only. The data is for reference only; users are solely responsible for any trading losses incurred from using this data. We assume no liability for errors, delayed updates, or transmission interruptions in the data.

--- a/docs/StressTest.en.md
+++ b/docs/StressTest.en.md
@@ -1,0 +1,48 @@
+
+## Load test results using ApacheBench
+
+### Querying the most-used `Taiwan stock real-time tick` endpoint
+
+* ### Test environment 1: Colab
+
+    Simulating 10 users sending 1,000 requests, the service handled ~10 requests/second on average,
+    or roughly 36,000 requests/hour.
+    Average response time: ~72 ms.
+
+    Detailed results:
+
+    ```
+    Concurrency Level:      10
+    Time taken for tests:   72.275 seconds
+    Complete requests:      1000
+    Failed requests:        0
+    Total transferred:      10179000 bytes
+    HTML transferred:       10019000 bytes
+    Requests per second:    13.84 [#/sec] (mean)
+    Time per request:       722.748 [ms] (mean)
+    Time per request:       72.275 [ms] (mean, across all concurrent requests)
+    Transfer rate:          137.54 [Kbytes/sec] received
+    ```
+
+
+* ### Test environment 2: Linode (Japan)
+
+    Simulating 10 users sending 1,000 requests, the service handled ~50 requests/second on average,
+    or roughly 180,000 requests/hour.
+    Average response time: ~17 ms.
+
+    Detailed results:
+
+    ```
+    Concurrency Level:      10
+    Time taken for tests:   17.095 seconds
+    Complete requests:      1000
+    Failed requests:        0
+    Total transferred:      10179000 bytes
+    HTML transferred:       10019000 bytes
+    Requests per second:    58.50 [#/sec] (mean)
+    Time per request:       170.947 [ms] (mean)
+    Time per request:       17.095 [ms] (mean, across all concurrent requests)
+    Transfer rate:          581.49 [Kbytes/sec] received
+    ```
+

--- a/docs/WhatIsNew.en.md
+++ b/docs/WhatIsNew.en.md
@@ -1,0 +1,354 @@
+#### 2026-05-06
+* [Taiwan Stock Trading Daily Report by Branch TaiwanStockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/) storage_objects docs: added a FinMind package example (`taiwan_stock_trading_daily_report(use_object=True)`).
+
+#### 2026-05-05
+* [Taiwan Stock Trading Daily Report by Branch TaiwanStockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/) added a storage_objects download path to fetch a whole day's data at once (sponsorpro members only).
+
+#### 2026-05-02
+* Added the "[Update Token](https://finmind.github.io/en/update_token/)" feature: users can reset their token themselves on the user info page. The old token becomes invalid immediately, with no need to contact support.
+
+#### 2026-04-30
+* Added [Loan Collateral Balance TaiwanStockLoanCollateralBalance](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockloancollateralbalance-sponsor)
+
+#### 2026-04-28
+* Added [Block Trade Daily Transaction Information TaiwanStockBlockTrade](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockblocktrade-sponsor)
+
+#### 2026-04-19
+* Added [Day Trading Securities Borrowing Fee Rate TaiwanStockDayTradingBorrowingFeeRate](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdaytradingborrowingfeerate-backersponsor)
+
+#### 2026-04-17
+* Added [Block Trade Daily Report TaiwanStockBlockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockblocktradingdailyreport-sponsor)
+
+#### 2026-04-12
+* [TaiwanStockPriceLimit](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockpricelimit-backersponsor) documentation update: 0 means no price limit.
+
+#### 2026-04-03
+* Added async batch query example.
+
+#### 2026-03-28
+* Updated [TaiwanStockDispositionSecuritiesPeriod](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdispositionsecuritiesperiod-backersponsor) documentation with ESB and TWSE data.
+
+#### 2026-03-26
+* Fixed mistakenly entered data range for the shareholding distribution table.
+
+#### 2026-03-21
+* [Agent Skill](https://finmind.github.io/en/tutor/AgentSkill/) added installation instructions and example screenshots for Claude Code, Cursor, Windsurf, and Gemini.
+* Updated [Contact](https://finmind.github.io/en/Contact/): replaced Gitter with the Facebook group and fan page.
+
+#### 2026-03-20
+* Added [Agent Skill](https://finmind.github.io/en/tutor/AgentSkill/) documentation, allowing tools such as Claude Code to query FinMind data quickly via skill.
+
+#### 2026-03-10
+* Added [llms.txt](https://finmind.github.io/llms.txt) and [llms-full.txt](https://finmind.github.io/llms-full.txt), helping AI tools understand FinMind documentation more quickly.
+* Added TaiwanStockPriceTick object method documentation.
+* Added an LLM / AI integration section to the homepage.
+
+#### 2026-03-06
+* Added [Daily Price Limit TaiwanStockPriceLimit](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockpricelimit-backersponsor)
+
+#### 2026-02-22
+* Updated futures and options real-time information documentation, adding supported codes and an explanation that an empty value retrieves all data.
+
+#### 2026-02-07
+* Added [Futures Spread Trading TaiwanFuturesSpreadTrading](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesspreadtrading-backersponsor)
+
+#### 2026-02-01
+* Added [Futures Final Settlement Price TaiwanFuturesFinalSettlementPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesfinalsettlementprice-backersponsor)
+* Added [Option Final Settlement Price TaiwanOptionFinalSettlementPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptionfinalsettlementprice-backersponsor)
+
+#### 2026-01-31
+* [TaiwanStockSuspended](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstocksuspended-backersponsor) and [TaiwanStockDayTradingSuspension](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockdaytradingsuspension-backersponsor) added FinMind package examples.
+
+#### 2026-01-24
+* Added [Taiwan Stock Suspended Trading Announcement TaiwanStockSuspended](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstocksuspended-backersponsor)
+* Added [Day Trading Sell-Then-Buy Suspension Notice TaiwanStockDayTradingSuspension](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockdaytradingsuspension-backersponsor)
+
+#### 2026-01-23
+* Added English translations to the documentation.
+
+#### 2026-01-22
+* Updated taiwan_options_snapshot documentation.
+
+#### 2026-01-18
+* Removed the token parameter from the API URL query; tokens are now passed via the header.
+
+#### 2026-01-04
+* Removed the `login` function; login is only supported via `login_by_token`.
+
+#### 2025-12-15
+* Enhanced the tick data async usage documentation.
+
+#### 2025-10-06
+* Added [Dividend Policy Table TaiwanStockDividend](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockdividend)
+
+#### 2025-09-21
+* Added the kind parameter to [Index Statistics Every 5 Seconds TaiwanStockEvery5SecondsIndex](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockevery5secondsindex-backersponsor).
+
+#### 2025-09-11
+* FinMind package added async batch query functionality.
+
+#### 2025-08-31
+* Added [Taiwan Stock Par Value Change Reference Price TaiwanStockParValueChange](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockparvaluechange)
+
+#### 2025-08-13
+* Added the suspension marker for sell-then-buy trades, and corrected the documentation for futures and options institutional investors.
+
+#### 2025-07-20
+* Added [Taiwan Stock Warrant Underlying Mapping Table TaiwanStockInfoWithWarrantSummary](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrantsummary-sponsor)
+* Added [Taiwan Stock Trading Date TaiwanStockTradingDate](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstocktradingdate)
+* Added [Taiwan Stock Post-Split Reference Price TaiwanStockSplitPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstocksplitprice)
+
+#### 2025-05-25
+* [Taiwan Stock Tick by Securities Trader TaiwanStockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocktradingdailyreport-sponsor) added FinMind package example.
+* [Taiwan Stock Warrant Tick by Securities Trader TaiwanStockWarrantTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockwarranttradingdailyreport-sponsor) added FinMind package example.
+
+#### 2025-05-11
+* Added [US Stock Minute Price USStockPriceMinute](https://finmind.github.io/en/tutor/UnitedStatesMarket/Technical/#usstockpriceminute-backersponsor)
+* [Company Industry Chain TaiwanStockIndustryChain](https://finmind.github.io/en/tutor/TaiwanMarket/Others/#taiwanstockindustrychain-backersponsor) added FinMind package example.
+
+#### 2025-05-10
+* Added [Index Statistics Every 5 Seconds TaiwanStockEvery5SecondsIndex](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockevery5secondsindex-backersponsor)
+* API authentication updated; tokens are now passed via the header `Authorization: Bearer <token>`.
+
+#### 2025-04-06
+* Added [Company Industry Chain TaiwanStockIndustryChain](https://finmind.github.io/en/tutor/TaiwanMarket/Others/#taiwanstockindustrychain-backersponsor)
+
+#### 2025-02-09
+* Added [Disposition Securities Period TaiwanStockDispositionSecuritiesPeriod](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdispositionsecuritiesperiod-backersponsor)
+
+#### 2025-01-05
+* TaiwanStockConvertibleBond, CnnFearGreedIndex, Futures/OptionOpenInterestLargeTraders, Futures/OptionInstitutionalInvestorsAfterHours, and TaiwanStockHoldingSharesPer are now available to backer-tier members.
+
+#### 2024-12-23
+* FinMind package added async batch query functionality.
+
+#### 2024-12-07
+* Added data range descriptions for [TaiwanBusinessIndicator](https://finmind.github.io/en/tutor/TaiwanMarket/Others/#taiwanbusinessindicator-backersponsor) and [CnnFearGreedIndex](https://finmind.github.io/en/tutor/Others/#cnnfeargreedindex).
+
+#### 2024-12-01
+* Added [Taiwan Monthly Business Indicator TaiwanBusinessIndicator](https://finmind.github.io/en/tutor/TaiwanMarket/Others/#taiwanbusinessindicator-backersponsor)
+
+#### 2024-11-17
+* Added [Taiwan Stock Market Value Weight TaiwanStockMarketValueWeight](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockmarketvalueweight-backersponsor)
+
+#### 2024-10-12
+* Added [Futures Open Interest Large Traders TaiwanFuturesOpenInterestLargeTraders](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesopeninterestlargetraders-backersponsor)
+* Added [Option Open Interest Large Traders TaiwanOptionOpenInterestLargeTraders](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptionopeninterestlargetraders-backersponsor)
+* Added [Futures After-Hours Institutional Investors TaiwanFuturesInstitutionalInvestorsAfterHours](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesinstitutionalinvestorsafterhours-backersponsor)
+* Added [Option After-Hours Institutional Investors TaiwanOptionInstitutionalInvestorsAfterHours](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptioninstitutionalinvestorsafterhours-backersponsor)
+
+#### 2024-09-28
+* Added [API usage query](https://finmind.github.io/en/api_usage_count/), allowing users to check api_usage and api_usage_limit through the package.
+
+#### 2024-09-26
+* [TaiwanStockTradingDailyReportSecIdAgg](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocktradingdailyreportsecidagg-sponsor) added securities_trader_id and end_date parameters.
+
+#### 2024-08-25
+* Added [Daily Securities Trader Aggregate Statistics TaiwanStockTradingDailyReportSecIdAgg](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocktradingdailyreportsecidagg-sponsor)
+
+#### 2024-07-14
+* Added [Taiwan Stock Weekly K-line TaiwanStockWeekPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockweekprice-backersponsor)
+* Added [Taiwan Stock Monthly K-line TaiwanStockMonthPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockmonthprice-backersponsor)
+
+#### 2024-05-28
+* Added [Taiwan Total Exchange Margin Maintenance TaiwanTotalExchangeMarginMaintenance](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwantotalexchangemarginmaintenance-backersponsor)
+
+#### 2024-05-19
+* Added FinMind package example for [Securities Trader Info TaiwanSecuritiesTraderInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwansecuritiestraderinfo).
+* Added data range description for [Capital Reduction Reference Price TaiwanStockCapitalReductionReferencePrice](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockcapitalreductionreferenceprice).
+
+#### 2024-05-08
+* Removed the exchange rate data source.
+
+#### 2024-04-18
+* Added [Margin Short Sale Suspension (Short Covering Date) TaiwanStockMarginShortSaleSuspension](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockmarginshortsalesuspension)
+
+#### 2024-04-01
+* Added FinMind package examples to the [Convertible Bond](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/) series of datasets.
+
+#### 2024-03-24
+* Added the convertible bond series of datasets:
+    * [Convertible Bond Overview TaiwanStockConvertibleBondInfo](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebondinfo-backersponsor)
+    * [Convertible Bond Daily Transaction Info TaiwanStockConvertibleBondDaily](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebonddaily-backersponsor)
+    * [Convertible Bond Institutional Investors Daily Trading Info TaiwanStockConvertibleBondInstitutionalInvestors](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebondinstitutionalinvestors-backersponsor)
+    * [Convertible Bond Daily Overview TaiwanStockConvertibleBondDailyOverview](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebonddailyoverview-backersponsor)
+
+#### 2024-03-19
+* Added [Taiwan Stock Delisting Table TaiwanStockDelisting](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockdelisting)
+
+#### 2024-01-27
+* Added column schema documentation for all market datasets.
+
+#### 2021-10-06
+* Released FinMind package 1.5.3, addressing the connect error issue.
+* Added FinMind package documentation.
+
+#### 2021-08-01
+* Removed real-time quotes due to data source issues.
+
+#### 2021-05-23
+* Added [Total Short Sale Balance Limit Table TaiwanDailyShortSaleBalances](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwandailyshortsalebalances)
+
+#### 2021-03-18
+* Added [Day Trading Securities and Trading Volume TaiwanStockDayTrading](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockdaytrading).
+
+
+#### 2021-02-22
+* Added the `streaming_all_data` parameter to retrieve real-time data (tick), covering all data from market open to the current moment.
+
+#### 2021-01-26
+* Added [CnnFearGreedIndex Fear and Greed Index](https://finmind.github.io/en/tutor/Others/#cnnfeargreedindex)
+* Registered users surpassed 500.
+
+#### 2021-01-25
+* [web](https://finmindtrade.com/) officially launched, including strategy analysis and backtesting features that analyze the win rate of stocks across the entire market to reduce survivorship bias.
+* Began the next phase of web development.
+
+
+#### 2021-01-18
+* Added [Futures and Options Institutional Investors Trading](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/)
+* Added [Futures and Options Daily Trading Information by Securities Trader](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/)
+* The web backtesting and strategy analysis features are scheduled to launch soon. They can analyze the win rate of all market stocks for a specific strategy to reduce survivorship bias.
+* api v4 is live, allowing users to retrieve all stock prices, institutional investor data, and margin trading information for a specific date in a single call. This makes daily updates more convenient by sending only a small number of requests.
+
+#### 2020-12-25
+* All data has been migrated to a time series database. For tick data, response speeds have improved by more than 10 times.
+* [web data download](https://finmindtrade.com/analysis/#/data/document)
+* [FinMind backtesting package documentation](https://finmind.github.io/en/tutor/analysis/Backtesting/) is being optimized.
+
+#### 2020-10-06
+* Plan to switch to a time series database to improve API efficiency.
+* Working on backtesting feature development.
+* Web development of the data download feature: since most users use Excel for financial analysis, we are developing the web Excel data download function.
+
+#### 2020-05-06
+* Added [Securities Lending Transaction Detail SecuritiesLending](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocksecuritieslending)
+* Added [Order Book and Trade Statistics Every 5 Seconds StockStatisticsOfOrderBookAndTrade](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#5-taiwanstockstatisticsoforderbookandtrade)
+
+
+#### 2020-05-01
+* Added [Taiwan Futures daily data](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesdaily)
+* Added [Taiwan Options daily data](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptiondaily)
+
+#### 2020-04-24
+* Added Taiwan Stock real-time best five bid/ask.
+* Added [Taiwan Futures real-time quotes](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#info-taiwanfutopttickinfo)
+
+#### 2020-04-15
+* Added documentation.
+* Added [Taiwan Stock real-time price](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockpriceminute)
+* Added [US Treasury Bond Yield](https://finmind.github.io/en/tutor/Macroeconomy/#governmentbondsyield)
+* Added [Taiwan Stock PER and PBR Table TaiwanStockPER](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockper)
+
+
+#### 2019-10-23
+* Added TotalMarginPurchaseShortSale: total daily margin purchase and short sale.
+* Added TaiwanStockNews: Taiwan stock-related news.
+
+#### 2019-10-10
+* Added TaiwanFutures: Taiwan futures trading detail.
+* Added TaiwanOption: Taiwan options trading detail.
+
+
+#### FinMind 1.0.80 (2019-07-15) 
+* Major update. Previously the package connected directly to the database; now it uses the API. Older versions of the package will stop working in the future and will not be able to connect directly to the database. Please upgrade to the latest version, or use the API directly.
+ 
+
+#### FinMind 1.0.70 (2019-06-23) 
+* add [api](https://github.com/linsamtw/FinMind/blob/master/api_demo.py)
+* add function `Mind.MoveAverage`, <br>
+e.g : 
+			
+			Mind.MoveAverage(_2330.StockPrice,days = 5,variable = 'close')
+			
+* add function `Mind.RSV`, <br>
+e.g : 
+	
+			Mind.RSV(_2330.StockPrice,days = 5)
+	
+* add function `Mind.BIAS`, <br>
+e.g : 
+	
+			Mind.BIAS(_2330.StockPrice,days = 5)
+
+  ----------------------
+#### FinMind 1.0.60 (2019-05-24) 
+* New data `TaiwanStockMonthRevenue`
+	
+			from FinMind.Data import Load
+			TaiwanStockMonthRevenue = Load.FinData(
+				dataset = 'TaiwanStockMonthRevenue',
+				select = '2330',
+				date = '2018-01-01')
+* Market index:
+	* TSEC weighted index ( Taiwan weighted index ) : stock_id - `^TWII`
+	* SP500 : stock_id - `^GSPC`
+	* Dow Jones Industrial Average : stock_id - `^DJI`
+
+  ----------------------
+#### FinMind 1.0.57 (2019-04-28) 
+* Change taiwan stock id, delete TWO and TW. ( eg. 2330.TW -> 2330 )
+
+#### FinMind 1.0.54 (2019-04-13) 
+* Optimize speeds of loading TaiwanStockPrice, USStockPrice
+* Add [DataSource](https://github.com/linsamtw/FinMind/blob/master/Data/DataSource.md)
+
+#### FinMind 1.0.53 (2019-04-07) 
+##### Fix FinMind.Data.Load
+* optimize speeds of loading data , ex :
+ 
+			from FinMind.Data import Load
+			import datetime
+
+			TaiwanStockInfo = Load.FinData(dataset = 'TaiwanStockInfo')
+			s = datetime.datetime.now()
+			TaiwanStockFinancialStatements = Load.FinData(dataset = 'FinancialStatements',select = list(TaiwanStockInfo['stock_id']),date = '2018-12-01')
+			t = datetime.datetime.now() - s
+			print(t)
+			0:00:01.861724
+  
+#### FinMind 1.0.52 (2019-04-06) 
+##### New Data
+* `BalanceSheet` ( Taiwan Balance Sheet )
+* `TaiwanStockHoldingSharesPer ` ( Taiwan Shareholding Distribution Table )
+* `Shareholding` ( Taiwan Foreign Shareholding by Stock )
+* `RawMaterialFuturesPrices ` ( US Raw Material Futures )
+#### New Function
+* `transpose(data)`
+* [demp2.py](https://github.com/linsamtw/FinMind/blob/master/demo2.py)
+
+#### 2018/8/5
+1. Central bank interest rates 100% ( 13 Countrys, Contains G8 )
+
+          FED Federal Reserve System (USA)
+          ECB European Central Bank (Europe)
+          BOE Bank of England (UK)
+          SNB Swiss National Bank (Switzerland)
+          RBA Reserve Bank of Australia (Australia)
+          BOC Bank of Canada (Canada)
+          RBNZ Reserve Bank of New Zealand (New Zealand)
+          BOJ Bank of Japan (Japan)
+          CBR The Central Bank of the Russian Federation (Russia)
+          RBI Reserve Bank of India (India)
+          PBOC People's Bank of China  (China)
+          BCB Banco Central do Brasil (Brazil)
+2. Gold Price 100%
+3. Government bond ->>>  https://data.oecd.org/interest/long-term-interest-rates.htm
+4. Futures ->>> https://www.investing.com/commodities/energies
+5. S&P 500 index, plus crawled prices of all 500 constituent stocks ->>>
+ 
+#### 2018/7/5 
+1. International oil prices: Load data example. (100%)
+3. Foreign exchange rates  ( 53 Countrys, Contains G8 )  (100%)
+
+#### 2018/7/2 Future crawler order
+2. Central bank interest rates from https://tradingeconomics.com/search.aspx?q=Interest%20Rate
+4. Inflation monthly from https://tradingeconomics.com/russia/inflation-cpi
+5. Consumer Price Index (CPI) monthly from https://tradingeconomics.com/russia/consumer-price-index-cpi
+6. Output Gap monthly from https://tradingeconomics.com/russia/gdp-deflator
+8. S&P 500 from yahoo finance
+9. Gold price from https://www.gold.org/data/gold-price
+
+
+
+

--- a/docs/api_usage_count.en.md
+++ b/docs/api_usage_count.en.md
@@ -1,0 +1,70 @@
+# API Usage Count
+
+#### Use your token to check the API usage count
+
+```
+GET: https://api.web.finmindtrade.com/v2/user_info
+
+```
+
+Headers:
+
+|Name          | Description  | Format   |
+|:------------:|:-------------:|:--------:|
+|Authorization | Token, obtained after sign-in | Bearer token |
+
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import FinMindApi
+
+        api = FinMindApi()
+        api.login_by_token(token)
+        print(api.api_usage_limit)
+        ```
+    === "Python"
+        ```python
+        import requests
+        headers = {"Authorization": f"Bearer {token}"}
+        url = "https://api.web.finmindtrade.com/v2/user_info"
+        payload = {
+            "token": token,
+        }
+        resp = requests.get(url, headers=headers)
+        resp.json()["user_count"]  # current usage
+        resp.json()["api_request_limit"]  # quota
+
+        ```
+
+#### When the quota is exceeded, the API returns:
+
+!!! danger
+    === "Example"
+        ```python
+        import requests
+        import pandas as pd
+        from tqdm import tqdm
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # see Login to obtain your token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPrice",
+            "data_id": "2330",
+            "start_date": "2020-04-02",
+            "end_date": "2020-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        print(resp.status_code)
+        print(resp.json())
+        ```
+
+!!! output
+    === "resp.status_code"
+        ```python
+        402
+        ```
+    === "resp.json()"
+        ```python
+        {'msg': 'Requests reach the upper limit. https://finmindtrade.com/', 'status': 402}
+        ```

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -1,0 +1,40 @@
+## LLM / AI Integration
+
+Want to query FinMind datasets and APIs through ChatGPT, Claude, or other AI tools? We provide `llms.txt`, which lets AI assistants quickly understand every FinMind dataset, API endpoint, and usage pattern.
+
+Just paste the link below to your AI assistant to start:
+
+- [llms.txt](https://finmind.github.io/llms.txt) — concise version, dataset index and API overview
+- [llms-full.txt](https://finmind.github.io/llms-full.txt) — full version, with all dataset columns, SDK methods, and parameter examples
+
+## What is FinMind?
+**FinMind** is an open-source platform offering more than 50 financial datasets focused on the Taiwan market, lowering the barrier to big data and financial analysis.
+
+* Technical:
+    * Taiwan stock info (with/without warrants), stock prices, adjusted prices, tick history, PER/PBR, 5-second order/trade aggregates, TAIEX, day trading volume, weighted/OTC return indices, 10-year stock data, K-bar data.
+* Fundamental:
+    * Cash flow statements, comprehensive income statements, balance sheets, dividend policy, ex-dividend results, monthly revenue, capital reduction reference price, market value, delisted stocks.
+* Chip (Institutional):
+    * Margin/short sale, institutional investor buy/sell, foreign investor holdings, shareholding tier, securities lending, credit limit balance, broker info, broker-level tick data, warrant tick data, eight major government bank buy/sell.
+* Derivatives:
+    * Futures/options daily overview, futures daily, options daily, futures/options trade detail, institutional buy/sell on futures/options, broker-level futures/options daily, futures/options real-time.
+* Convertible Bonds:
+    * Convertible bond info, daily, institutional buy/sell, daily overview.
+* Real-Time:
+    * Taiwan stock real-time, futures real-time, options real-time.
+* News: Taiwan stock news.
+* International Markets:
+    * US stock daily/minute, US Treasury yields, US money supply, gold, crude oil, G8 central bank rates, G8 exchange rates.
+
+Datasets are updated daily — no data collection needed before you start analyzing. More datasets are continually added.
+
+## What is it?
+**FinMind** is open source of more than [50 datasets](https://finmind.github.io/en/), containing
+
+Taiwan stock trade data daily, tick, Financial Statements, Balance Sheet, Cash Flows Statement, Month Revenue, Holding Shares Per, Institutional Investors Buy Sell. Taiwan Futures Trade Detail, Taiwan Option Trade Detail.
+
+US stock price daily, minute (2021-04-28 ~ now, total more than 80 million data), oil price, gold price, [G7](https://en.wikipedia.org/wiki/Group_of_Seven) exchange rate, interest rate. <br>
+US Government Bonds Yield.
+
+The datasets are automatically updated daily.
+You can analyze financial data without having to collect the data by yourself.<br>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -12,6 +12,25 @@ Register at finmindtrade.com, get token via login API or website. Pass token as 
 
 Rate limit: 600 requests/hour (with token), 300/hour (without token).
 
+#### Update Token (Self-Service Reset)
+
+If you suspect your token has leaked, reset it yourself on the [user info page](https://finmindtrade.com/analysis/#/account/user) — no need to contact support.
+
+Steps:
+
+1. Open the [user info page](https://finmindtrade.com/analysis/#/account/user)
+2. Under the `api token` field, click the "Update Token" button
+3. Confirm — a new token is generated immediately
+
+Behavior:
+
+- Generates a new token in one click
+- Old token is invalidated immediately
+- All devices are signed out and must log in again to obtain the new token
+- Self-service — no support ticket required
+
+Tip: rotate your token regularly to keep your account secure.
+
 ### Endpoints
 
 #### POST /login

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -48,6 +48,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 
 - [Quick Start](https://finmind.github.io/quickstart/): API usage guide with examples in Python and R
 - [Login](https://finmind.github.io/login/): Authentication methods
+- [Update Token](https://finmind.github.io/update_token/): Self-service token reset on the [user info page](https://finmindtrade.com/analysis/#/account/user). Old token is invalidated immediately and all devices are signed out — no need to contact support.
 - [API Usage Count](https://finmind.github.io/api_usage_count/): Check API usage via `GET https://api.web.finmindtrade.com/v2/user_info` (Authorization: Bearer {token}). Returns `user_count` (current usage) and `api_request_limit` (quota). HTTP 402 when quota exceeded.
 
 ### Taiwan Market (77 datasets)

--- a/docs/login.en.md
+++ b/docs/login.en.md
@@ -1,0 +1,49 @@
+# Login
+
+#### Sign in on the [official site](https://finmindtrade.com/analysis/#/account/user). Your API token is shown on the user info page — attach it to subsequent FinMind calls.
+
+
+!!! package-example
+    === "Login by token"
+        ```python hl_lines="4"
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+        ```
+
+!!! request-example
+    === "Python"
+        ```python hl_lines="2 3"
+        import requests
+        token = "" # see Login above to obtain your token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPrice",
+            "data_id": "2330",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        resp = data.json()
+
+        ```
+    === "R"
+        ```R hl_lines="4 13"
+        library(httr)
+        library(data.table)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # see Login above to obtain your token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPrice",
+                data_id= "2330",
+                start_date= "2020-01-02",
+                end_date= "2020-04-12",
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+
+        ```

--- a/docs/quickstart.en.md
+++ b/docs/quickstart.en.md
@@ -1,0 +1,111 @@
+# Quick start with FinMind Finance data API
+
+This guide walks you through how to use the FinMind data API.
+
+* :warning: Rate limit
+
+    Request limit: 600/hour with token, 300/hour without token.<br>
+    After registering at [FinMind](https://finmindtrade.com/analysis/#/account/register) and verifying your email, attaching the `token` parameter raises your limit to 600/hour.<br>
+    Get the token by signing in on the [official site](https://finmindtrade.com/analysis/#/account/login).
+
+## FinMind data API has four main endpoints
+
+- Login API
+
+    Get a token; pass it on subsequent calls to raise your rate limit.
+
+    ```
+    https://api.finmindtrade.com/api/v4/login
+    ```
+
+- Data API
+
+    Fetch a dataset. For example, query Taiwan stock prices via `TaiwanStockPrice`.
+
+    ```
+    https://api.finmindtrade.com/api/v4/data
+    ```
+
+- Datalist API
+
+    Each dataset takes parameters such as `data_id`. Use this endpoint to discover the available values — for example, list every currency available for `TaiwanExchangeRate`.
+
+    ```
+    https://api.finmindtrade.com/api/v4/datalist
+    ```
+
+- Translation API
+
+    Some columns are only labeled in English with cryptic names. This endpoint returns the Chinese name. For example, `AccountsPayable` in the balance sheet maps to **應付帳款 (accounts payable)**.
+
+    ```
+    https://api.finmindtrade.com/api/v4/translation
+    ```
+
+## API description
+
+#### login
+
+```
+POST: https://api.finmindtrade.com/api/v4/login
+
+```
+
+Request parameters:
+
+Name          | Type  | Required | Description
+--------------|:-----:|---------:|------------------------
+user_id       | str   |  N | User ID — [register](https://finmindtrade.com/analysis/#/account/register) for higher quota.
+password      | str   |  N | User password — [register](https://finmindtrade.com/analysis/#/account/register) for higher quota.
+
+```
+response: token
+```
+
+
+#### Data API
+
+```
+GET: https://api.finmindtrade.com/api/v4/data
+
+```
+
+Request parameters:
+
+Name          | Type  | Required | Description
+--------------|:-----:|---------:|------------------------
+dataset       | str   |  Y | Dataset name
+data_id       | str   |  N | Data identifier (e.g., stock id)
+start_date    | str   |  N | Start date. With `end_date`, returns the range; alone, returns from `start_date` to latest. At least one of `start_date` / `end_date` is required.
+end_date      | str   |  N | End date. With `start_date`, returns the range; alone, returns up to `end_date`. At least one of `start_date` / `end_date` is required.
+token         | str   |  N | User token — see [Login](https://finmind.github.io/en/login/) to obtain one.
+
+#### Datalist API
+
+```
+GET: https://api.finmindtrade.com/api/v4/datalist?
+```
+
+Request parameters:
+
+Name          | Type  | Required | Description
+--------------|:-----:|---------:|------------------------
+dataset       | str   |  Y | Dataset name
+user_id       | str   |  N | User ID — [register](https://finmindtrade.com/analysis/#/account/register) for higher quota.
+password      | str   |  N | User password — [register](https://finmindtrade.com/analysis/#/account/register) for higher quota.
+
+#### Translation API
+
+```
+GET: https://api.finmindtrade.com/api/v4/translation?
+```
+
+Request parameters:
+
+Name          | Type  | Required | Description
+--------------|:-----:|---------:|------------------------
+dataset       | str   |  Y | Dataset name
+user_id       | str   |  N | User ID — [register](https://finmindtrade.com/analysis/#/account/register) for higher quota.
+password      | str   |  N | User password — [register](https://finmindtrade.com/analysis/#/account/register) for higher quota.
+
+

--- a/docs/release.en.md
+++ b/docs/release.en.md
@@ -1,0 +1,206 @@
+## version: 1.6.2 (2023-09-24)
+
+## What's Changed
+* add: change the status code by @machineCYC in https://github.com/FinMind/FinMind/pull/262
+* add: tw 10 year avg close by @machineCYC in https://github.com/FinMind/FinMind/pull/267
+* add: remove the adj calculate code by @machineCYC in https://github.com/FinMind/FinMind/pull/269
+* feat: Use pandas concat instead of append by @linsamtw in https://github.com/FinMind/FinMind/pull/265
+
+
+:zap: release_at: 2023-09-24 07:24:55
+
+## version: 1.6.1 (2023-06-22)
+
+## What's Changed
+* fix: ex_dividend_price end date need to be the same as the stock_price by @machineCYC in https://github.com/FinMind/FinMind/pull/252
+* add: taiwan_securities_trader_info api in finmind package by @machineCYC in https://github.com/FinMind/FinMind/pull/256
+* add: taiwan stock market value by @machineCYC in https://github.com/FinMind/FinMind/pull/257
+* feat: add taiwan_stock_info_with_warrant, taiwan_stock_tick_snapshot, taiwan_futures_snapshot, taiwan_options_snapshot by @linsamtw in https://github.com/FinMind/FinMind/pull/258
+
+
+
+
+:zap: release_at: 2023-06-22 05:51:52
+
+## version: 1.5.8 (2022-09-13)
+
+* feat: add Capital Reduction Reference Price
+
+:zap: release_at: 2022-09-13 15:47:08
+
+## version: 1.5.7 (2022-09-06)
+
+* feat: remove taiwan futopt institutional investors api, add taiwan_future_institutional_investors and taiwan_option_institutional_investors api
+
+:zap: release_at: 2022-09-06 15:42:02
+
+## version: 1.5.6 (2022-06-16)
+
+
+
+:zap: release_at: 2022-06-16 10:45:04
+
+## version: 1.5.5 (2021-11-02)
+
+* feat: reset timeout defacut value None and logger.info timeout msg (#192)
+
+:zap: release_at: 2021-11-02 11:15:11
+
+## version: 1.5.4 (2021-10-31)
+
+* Hotfix: fix some dependency issue (#190), 
+* fix: remove error msg not show issue (#191)
+
+:zap: release_at: 2021-10-31 16:53:19
+
+## version: 1.5.3 (2021-10-06)
+
+* fix: taiwan_futopt_daily_info (#189)
+
+:zap: release_at: 2021-10-06 12:10:04
+
+## version: 1.5.2 (2021-10-06)
+
+* debug: Unable to parse datetime string 
+
+:zap: release_at: 2021-10-06 11:17:40
+
+## version: 1.5.1 (2021-10-05)
+
+* feat: handle connection errors
+
+
+:zap: release_at: 2021-10-05 17:29:22
+
+## version: 1.5.0 (2021-09-11)
+
+* feat: add timeout and retry on request get 
+* feat: add timeout params, default 30 seconds
+
+:zap: release_at: 2021-09-11 18:00:16
+
+## version: 1.4.9 (2021-07-25)
+
+* feat: add flask post.html 
+
+:zap: release_at: 2021-07-25 05:52:39
+
+## version: 1.4.8 (2021-07-11)
+
+* feat: add bar, line, pie plot, 
+* feat: add TaiwanStockTotalReturnIndex
+* feat: change numpy version
+
+:zap: release_at: 2021-07-11 14:30:37
+
+## version: 1.4.7 (2021-07-03)
+
+* fix: data loader pd.Period convert 
+
+:zap: release_at: 2021-07-03 11:02:53
+
+## version: 1.4.6 (2021-06-27)
+
+* feat: add kline_margin_purchase_short_sale, 
+* fix: taiwan_stock_daily_adj
+
+:zap: release_at: 2021-06-27 14:13:56
+
+## version: 1.4.5 (2021-06-20)
+
+* feat: add kline institutional_investors
+* fix issue #153 
+
+:zap: release_at: 2021-06-20 05:25:40
+
+## version: 1.4.4 (2021-06-13)
+
+* feat: add start_date, end_date transfer, 
+* fix: [issue](https://github.com/FinMind/FinMind/issues/142) remove suspension trading data 
+
+:zap: release_at: 2021-06-13 07:14:19
+
+## version: 1.4.3 (2021-05-24)
+
+* feat: add streaming_all_data
+
+:zap: release_at: 2021-05-24 16:36:52
+
+## version: 1.4.2 (2021-05-24)
+
+* fix: event loop can not exit issue 
+
+:zap: release_at: 2021-05-24 12:57:07
+
+## version: 1.4.1 (2021-05-23)
+
+* feat: data loader add dataset
+* feat: add docstrings
+
+:zap: release_at: 2021-05-23 17:44:18
+
+## version: 1.4.0 (2021-05-23)
+
+* feat: add DataSubscriber
+* fix: kline ex-devidend date and trading date not match
+
+:zap: release_at: 2021-05-23 09:12:20
+
+## version: 1.3.9 (2021-04-26)
+
+* feat: add data loader, plotting
+
+:zap: release_at: 2021-04-26 00:36:30
+
+## version: 1.3.8 (2021-03-21)
+
+- Fix adjusted stock price spread
+
+:zap: release_at: 2021-03-21 13:03:10
+
+## version: 1.3.7 (2021-03-16)
+
+- Add Taiwan stock retroactive_price (adjusted stock price)
+
+:zap: release_at: 2021-03-16 14:05:41
+
+## version: 1.3.6 (2021-03-09)
+
+* feat: add EarningsDistribution 
+
+:zap: release_at: 2021-03-09 05:49:14
+
+## version: 1.3.5 (2021-03-08)
+
+* fix: TAIEX dropna 
+
+:zap: release_at: 2021-03-08 10:52:44
+
+## version: 1.3.4 (2021-01-24)
+
+- Add backtesting Taiwan market same-period annualized return
+- Remove tax and fee from the trade_detail property in backtesting
+- Add EverytimeTotalProfit (total assets) to the trade_detail property in backtesting
+- Add descriptions for the kd, Naitvekd, and ContinueHolding strategies
+- Add the first day backtesting result
+
+:zap: release_at: 2021-01-24 08:22:30
+
+## version: 1.3.3 (2021-01-14)
+
+* feat: update pandas version
+
+:zap: release_at: 2021-01-14 07:45:49
+
+## version: 1.3.2 (2021-01-14)
+
+* feat: add add_strategy
+
+:zap: release_at: 2021-01-14 07:17:41
+
+## version: 1.3.0 (2021-01-10)
+
+* fix: version
+
+:zap: release_at: 2021-01-10 13:33:35
+

--- a/docs/tutor/AgentSkill.en.md
+++ b/docs/tutor/AgentSkill.en.md
@@ -1,0 +1,185 @@
+FinMind provides an AI Agent Skill that lets you query 75+ FinMind datasets through natural language inside AI tools such as [Gemini](https://gemini.google.com/), [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [Codex](https://github.com/openai/codex), [Cursor](https://www.cursor.com/), and [Windsurf](https://windsurf.com/), without having to assemble API parameters yourself.
+
+## Installation
+
+### Step 1: Download the Skill
+
+!!! example
+    === "Claude Code"
+        ```bash
+        mkdir -p ~/.claude/commands
+        curl -o ~/.claude/commands/finmind.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Codex"
+        ```bash
+        curl -o AGENTS.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Cursor"
+        ```bash
+        mkdir -p .cursor/rules
+        curl -o .cursor/rules/finmind.mdc https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Windsurf"
+        ```bash
+        curl -o .windsurfrules https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Gemini"
+        ```bash
+        curl -o GEMINI.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+
+### Step 2: Set Up the Token
+
+Register at [FinMind](https://finmindtrade.com/analysis/#/account/register) and verify your email to obtain a token.
+
+```bash
+export FINMIND_TOKEN="your_token_here"
+```
+
+We recommend adding this to `~/.bashrc` or `~/.zshrc` so it loads automatically every time you open a terminal.
+
+### Step 3: Use It
+
+In Claude Code, type `/finmind` followed by what you want to query:
+
+```
+/finmind TSMC stock prices for the past month
+```
+
+---
+
+## Examples
+
+### Stock Price Queries
+
+```
+/finmind TSMC stock prices for the past month
+```
+
+> Expected result: returns a daily stock price table for TSMC (2330) over the past month, including columns such as date, open, high, low, close, and volume.
+
+![TSMC stock prices for the past month](../img/tsmc_1m_price.png)
+
+```
+/finmind Compare 2330 and 2317 stock prices over the past three months
+```
+
+> Expected result: queries TSMC and Hon Hai stock prices over the past three months and presents a closing-price comparison of both stocks in a table.
+
+![Compare 2330 and 2317 stock prices over the past three months](../img/compare_2330_2317.png)
+
+### Chip / Institutional Data
+
+```
+/finmind 2330 institutional investors trading over the past week
+```
+
+> Expected result: returns daily net buy/sell volumes (in lots) for foreign investors, investment trusts, and dealers for TSMC over the past week.
+
+![2330 institutional investors trading over the past week](../img/institutional_2330.png)
+
+```
+/finmind TSMC foreign investor shareholding ratio history
+```
+
+> Expected result: returns a historical table of TSMC's foreign investor shareholding (in lots) and shareholding ratio.
+
+![TSMC foreign investor shareholding ratio history](../img/tsmc_foreign_shareholding.png)
+
+### Fundamentals
+
+```
+/finmind TSMC monthly revenue this year
+```
+
+> Expected result: returns TSMC's monthly revenue figures for the current year.
+
+![TSMC monthly revenue this year](../img/tsmc_monthly_revenue.png)
+
+```
+/finmind 2330 PER trend over the past five years
+```
+
+> Expected result: returns TSMC's historical price-to-earnings ratio (PER), price-to-book ratio (PBR), and dividend yield over the past five years.
+
+### Futures and Options
+
+```
+/finmind TAIEX near-month futures contract weekly trading info
+```
+
+> Expected result: returns daily open/high/low/close, volume, and open interest for TAIEX futures (TX) over the past week.
+
+![TAIEX near-month futures contract weekly trading info](../img/taiex_futures_weekly.png)
+
+```
+/finmind TAIEX options institutional investors trading today
+```
+
+> Expected result: returns today's long/short trading volumes (in contracts) and amounts by the three institutional investors for TAIEX options (TXO).
+
+### Macroeconomy
+
+```
+/finmind USD/TWD exchange rate trend over the past six months
+```
+
+> Expected result: returns daily spot buy/sell USD/TWD exchange rates over the past six months.
+
+![USD/TWD exchange rate trend over the past six months](../img/usd_twd_exchange_rate.png)
+
+```
+/finmind Federal Reserve interest rate changes over the past ten years
+```
+
+> Expected result: returns the Fed's historical interest rate adjustment records over the past ten years.
+
+```
+/finmind Gold price trend over the past year
+```
+
+> Expected result: returns daily gold prices over the past year.
+
+### Charts
+
+```
+/finmind TSMC candlestick chart for the past three months
+```
+
+> Expected result: generates a candlestick chart for TSMC over the past three months, including OHLC, moving averages, and volume, saved as an image file.
+
+![TSMC 2330 Candlestick Chart](../img/tsmc_3m_kbar.png)
+
+```
+/finmind Compare 2330 and 2317 stock prices over the past six months, plot a chart
+```
+
+> Expected result: generates a line chart comparing the closing prices of the two stocks, saved as an image file.
+
+![2330 vs 2317 Stock Comparison](../img/stock_comparison_2330_2317.png)
+
+```
+/finmind USD exchange rate trend chart for the past year
+```
+
+> Expected result: generates a USD/TWD exchange rate line chart, saved as an image file.
+
+### Advanced Analysis
+
+```
+/finmind Compare TSMC and MediaTek stock returns over the past year
+```
+
+> Expected result: calculates the cumulative return rates of both stocks over the past year and presents the comparison in a table or chart.
+
+```
+/finmind 2330 dividend policy summary for the past three years
+```
+
+> Expected result: summarizes TSMC's cash dividends, stock dividends, ex-dividend dates, and payment dates for the past three years.
+
+```
+/finmind TAIEX index every-5-second trend today
+```
+
+> Expected result: returns the TAIEX weighted index value every 5 seconds for today, showing the intraday trend.

--- a/docs/tutor/EuropeMarket/DataList.en.md
+++ b/docs/tutor/EuropeMarket/DataList.en.md
@@ -1,0 +1,9 @@
+In the European financial market, we offer 1 dataset, as follows:
+
+- [Europe Stock List EuropeStockInfo](https://finmind.github.io/en/tutor/EuropeMarket/Technical/#europestockinfo)
+
+#### Stock Price TaiwanStock
+
+- [Europe Stock Price Table EuropeStockPrice](https://finmind.github.io/en/tutor/EuropeMarket/Technical/#europestockprice)
+
+For specific schemas, please refer to [finmind](https://finmindtrade.com/analysis/#/data/document)

--- a/docs/tutor/EuropeMarket/Technical.en.md
+++ b/docs/tutor/EuropeMarket/Technical.en.md
@@ -1,0 +1,92 @@
+In European stock data, we offer 1 dataset, as follows:
+
+- [Europe Stock Price Table EuropeStockPrice](https://finmind.github.io/en/tutor/EuropeMarket/Technical/#europestockprice)
+
+In addition, the following list summarizes the available datasets:
+
+- [Europe Stock List EuropeStockInfo](https://finmind.github.io/en/tutor/EuropeMarket/Technical/#europestockinfo)
+
+The usage of each dataset is explained one by one below. For the specific dataset schemas, please refer to [finmindapi](http://api.finmindtrade.com/docs#/default/method_api_v3_data_get)
+
+#### Europe Stock List EuropeStockInfo
+
+- This dataset primarily lists the names, codes, and industry categories of all European listed and OTC stocks.
+
+!!! example
+   ```python
+   import requests
+   import pandas as pd
+
+   url = 'https://api.finmindtrade.com/api/v4/data'
+   token = "" # Refer to the login page to obtain your API key
+   headers = {"Authorization": f"Bearer {token}"}
+   parameter = {
+      "dataset": "EuropeStockInfo"
+   }
+   data = requests.get(url, headers=headers, params=parameter)
+   data = data.json()
+   data = pd.DataFrame(data['data'])
+   print(data.head())
+   ```
+!!! output
+    === "DataFrame"
+         |    | date       | stock_id   | Market             | stock_name         |
+         |---:|:-----------|:-----------|:-------------------|:-------------------|
+         |  0 | 2019-01-14 | 2CRSI.PA   | Euronext Paris     | 2CRSI              |
+         |  1 | 2019-01-14 | AAA.AS     | Euronext Amsterdam | AP ALTERNAT ASSETS |
+         |  2 | 2019-01-14 | AALB.AS    | Euronext Amsterdam | AALBERTS INDUSTR   |
+         |  3 | 2019-01-14 | AB.PA      | Euronext Paris     | AB SCIENCE         |
+         |  4 | 2019-01-14 | ABCA.PA    | Euronext Paris     | ABC ARBITRAGE      |
+    === "Schema"
+        ```
+        {
+            date: str,
+            stock_id: str,
+            Market: str,
+            stock_name: str
+        }
+        ```
+
+#### Europe Stock Price Table EuropeStockPrice
+
+!!! example
+   ```python
+   import requests
+   import pandas as pd
+
+   url = 'https://api.finmindtrade.com/api/v4/data'
+   token = "" # Refer to the login page to obtain your API key
+   headers = {"Authorization": f"Bearer {token}"}
+   parameter = {
+       "dataset": "EuropeStockPrice",
+       "data_id": "AALB.AS",
+       "start_date": "2020-06-16",
+       "end_date": "2021-06-16",
+   }
+   data = requests.get(url, headers=headers, params=parameter)
+   data = data.json()
+   data = pd.DataFrame(data['data'])
+   print(data.head())
+   ```
+!!! output
+    === "DataFrame"
+         |    | date       | stock_id   |   Adj_Close |   Close |   High |   Low |   Open |   Volume |
+         |---:|:-----------|:-----------|------------:|--------:|-------:|------:|-------:|---------:|
+         |  0 | 2020-06-16 | AALB.AS    |       26.82 |   28.37 |  29.03 | 27.99 |  28.35 |   603839 |
+         |  1 | 2020-06-17 | AALB.AS    |       26.81 |   28.35 |  28.88 | 28.26 |  28.38 |   512502 |
+         |  2 | 2020-06-18 | AALB.AS    |       27.15 |   28.71 |  29.05 | 28.01 |  28.34 |   452985 |
+         |  3 | 2020-06-19 | AALB.AS    |       26.47 |   28    |  29    | 27.97 |  29    |  1466512 |
+         |  4 | 2020-06-22 | AALB.AS    |       26.57 |   28.1  |  28.34 | 27.5  |  28    |   281713 |
+    === "Schema"
+        ```
+        {
+            date: str,
+            stock_id: str,
+            Adj_Close: float32,
+            Close: float32,
+            High: float32,
+            Low: float32,
+            Open: float32,
+            Volume: int64
+        }
+        ```

--- a/docs/tutor/ExchangeRate.en.md
+++ b/docs/tutor/ExchangeRate.en.md
@@ -1,0 +1,51 @@
+In the foreign exchange market, we offer 19 currency datasets, as follows:
+
+- [Foreign Currency to TWD Exchange Rate Table TaiwanExchangeRate](https://finmind.github.io/en/tutor/InterestRate/#taiwanexchangerate)
+
+In addition, the following list summarizes the available currencies. There are currently 19 of them.
+
+| data_id 	| AUD  	| CAD    	| CHF      	| CNY    	| EUR  	| GBP  	| HKD  	| IDR    	| JPY  	| KRW  	| MYR    	| NZD  	| PHP      	| SEK    	| SGD      	| THB  	| USD  	| VND    	| ZAR    	|
+|---------	|------	|--------	|----------	|--------	|------	|------	|------	|--------	|------	|------	|--------	|------	|----------	|--------	|----------	|------	|------	|--------	|--------	|
+| Currency  	| Australia 	| Canada 	| Swiss Franc 	| Chinese Yuan 	| Euro 	| British Pound 	| Hong Kong Dollar 	| Indonesian Rupiah 	| Japanese Yen 	| South Korean Won 	| Malaysian Ringgit 	| New Zealand Dollar 	| Philippine Peso 	| Swedish Krona 	| Singapore Dollar 	| Thai Baht 	| US Dollar 	| Vietnamese Dong 	| South African Rand 	|
+
+
+#### Foreign Currency to TWD Exchange Rate Table TaiwanExchangeRate
+
+- USD demonstration
+
+!!! example
+     ```python
+     import requests
+     import pandas as pd
+     url = "https://api.finmindtrade.com/api/v4/data"
+     token = "" # Refer to the login page to obtain your API key
+     headers = {"Authorization": f"Bearer {token}"}
+     parameter = {
+          "dataset": "TaiwanExchangeRate",
+          "data_id": "USD",
+          "start_date": "2006-01-01",
+     }
+     data = requests.get(url, headers=headers, params=parameter)
+     data = data.json()
+     data = pd.DataFrame(data['data'])
+     print(data.head())
+
+          date currency  cash_buy  cash_sell  spot_buy  spot_sell
+     0  2006-01-02      USD    32.470     33.005   -99.000    -99.000
+     1  2006-01-03      USD    32.295     32.830    32.595     32.695
+     2  2006-01-04      USD    31.985     32.520    32.285     32.385
+     3  2006-01-05      USD    31.670     32.205    31.970     32.070
+     4  2006-01-06      USD    31.830     32.372    32.130     32.230
+     ```
+!!! output
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            currency: str, # currency
+            cash_buy: float64, # cash buying rate
+            cash_sell: float64, # cash selling rate
+            spot_buy: float64, # spot buying rate
+            spot_sell: float64 # spot selling rate
+        }
+        ```

--- a/docs/tutor/GovernmentBondsYield.en.md
+++ b/docs/tutor/GovernmentBondsYield.en.md
@@ -1,0 +1,45 @@
+For US Treasury bonds, we offer 12 US Treasury bond datasets, as follows:
+
+
+
+
+| data_id|	United States 1-Month|	United States 2-Month|	United States 3-Month|	United States 6-Month|	United States 1-Year|	United States 2-Year|	United States 3-Year|	United States 5-Year|	United States 7-Year|	United States 10-Year|	United States 20-Year|	United States 30-Year    	|
+|---------	|--------	|--------	|--------	|--------	|--------	|--------	|--------	|--------	|--------	|--------	|--------	|--------	|
+| Bond|	1-Month|	2-Month|	3-Month|	6-Month|	1-Year|	2-Year|	3-Year|	5-Year|	7-Year|	10-Year|	20-Year|	30-Year| 	|
+
+
+#### US Government Bonds Yield GovernmentBondsYield
+
+!!! example
+    ```python
+    import requests
+    import pandas as pd
+
+    url = "https://api.finmindtrade.com/api/v4/data"
+    token = "" # Refer to the login page to obtain your API key
+    headers = {"Authorization": f"Bearer {token}"}
+    parameter = {
+        "dataset": "GovernmentBondsYield",
+        "data_id": "United States 1-Month",
+        "start_date": "2020-01-01",
+    }
+    data = requests.get(url, headers=headers, params=parameter)
+    data = data.json()
+    data = pd.DataFrame(data['data'])
+    print(data.head())
+              date                   name  value
+    0  2020-01-02  United States 1-Month   1.53
+    1  2020-01-03  United States 1-Month   1.52
+    2  2020-01-06  United States 1-Month   1.54
+    3  2020-01-07  United States 1-Month   1.52
+    4  2020-01-08  United States 1-Month   1.50
+    ```
+!!! output
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            name: str, # category
+            value: float32 # price
+        }
+        ```

--- a/docs/tutor/InterestRate.en.md
+++ b/docs/tutor/InterestRate.en.md
@@ -1,0 +1,46 @@
+In the interest rate market, we offer datasets from 12 central banks, as follows:
+
+- [Interest Rate Table InterestRate](https://finmind.github.io/en/tutor/InterestRate/#interestrate)
+
+| data_id 	| BOE        	| RBA          	| FED          	| PBOC         	| BOC      	| ECB          	| RBNZ           	| RBI          	| CBR            	| BCB              	| BOJ      	| SNB          	|
+|---------	|------------	|--------------	|--------------	|--------------	|----------	|--------------	|----------------	|--------------	|----------------	|------------------	|----------	|--------------	|
+| Country 	| Bank of England 	| Reserve Bank of Australia 	| Federal Reserve 	| People's Bank of China 	| Bank of China 	| European Central Bank 	| Reserve Bank of New Zealand 	| Reserve Bank of India 	| Central Bank of Russia 	| Central Bank of Brazil 	| Bank of Japan 	| Swiss National Bank 	|
+
+#### Interest Rate Table InterestRate
+
+- FED demonstration
+
+!!! example
+  ```python
+  import requests
+  import pandas as pd
+  url = "https://api.finmindtrade.com/api/v4/data"
+  token = "" # Refer to the login page to obtain your API key
+  headers = {"Authorization": f"Bearer {token}"}
+  parameter = {
+      "dataset": "InterestRate",
+      "data_id": "FED",
+      "start_date": "1982-01-01",
+  }
+  data = requests.get(url, headers=headers, params=parameter)
+  data = data.json()
+  data = pd.DataFrame(data['data'])
+  print(data.head())
+
+    country        date full_country_name  interest_rate
+  0     FED  1982-09-27   Federal Reserve          10.25
+  1     FED  1982-10-01   Federal Reserve          10.00
+  2     FED  1982-10-07   Federal Reserve           9.50
+  3     FED  1982-11-19   Federal Reserve           9.00
+  4     FED  1982-12-14   Federal Reserve           8.50
+  ```
+!!! output
+    === "Schema"
+        ```
+        {
+            country: str, # country
+            date: str, # date
+            full_country_name: str, # full country name
+            interest_rate: float32 # interest rate
+        }
+        ```

--- a/docs/tutor/JapanMarket/DataList.en.md
+++ b/docs/tutor/JapanMarket/DataList.en.md
@@ -1,0 +1,9 @@
+In the Japanese financial market, we offer 1 dataset, as follows:
+
+- [Japan Stock List JapanStockInfo](https://finmind.github.io/en/tutor/JapanMarket/Technical/#japanstockinfo)
+
+#### Stock Price TaiwanStock
+
+- [Japan Stock Price Table JapanStockPrice](https://finmind.github.io/en/tutor/JapanMarket/Technical/#japanstockprice)
+
+For specific schemas, please refer to [finmind](https://finmindtrade.com/analysis/#/data/document)

--- a/docs/tutor/JapanMarket/Technical.en.md
+++ b/docs/tutor/JapanMarket/Technical.en.md
@@ -1,0 +1,94 @@
+In Japanese stock data, we offer 1 dataset, as follows:
+
+- [Japan Stock Price Table JapanStockPrice](https://finmind.github.io/en/tutor/JapanMarket/Technical/#japanstockprice)
+
+In addition, the following list summarizes the available datasets:
+
+- [Japan Stock List JapanStockInfo](https://finmind.github.io/en/tutor/JapanMarket/Technical/#japanstockinfo)
+
+The usage of each dataset is explained one by one below. For the specific dataset schemas, please refer to [finmindapi](http://api.finmindtrade.com/docs#/default/method_api_v3_data_get)
+
+#### Japan Stock List JapanStockInfo
+
+- This dataset primarily lists the names, codes, and industry categories of all Japanese listed and OTC stocks.
+
+!!! example
+   ```python
+   import requests
+   import pandas as pd
+
+   url = 'https://api.finmindtrade.com/api/v4/data'
+   token = "" # Refer to the login page to obtain your API key
+   headers = {"Authorization": f"Bearer {token}"}
+   parameter = {
+      "dataset": "JapanStockInfo"
+   }
+   data = requests.get(url, headers=headers, params=parameter)
+   data = data.json()
+   data = pd.DataFrame(data['data'])
+   print(data.head())
+   ```
+!!! output
+    === "DataFrame"
+         |    | date       | stock_id   | Exchange   | Sector        | stock_name                |
+         |---:|:-----------|:-----------|:-----------|:--------------|:--------------------------|
+         |  0 | 2019-01-14 | 1301.T     | XTKS       | Food Products | Kyokuyo Co. Ltd.          |
+         |  1 | 2019-01-14 | 1332.T     | XTKS       | Fishing       | Nippon Suisan Kaisha Ltd. |
+         |  2 | 2019-01-14 | 1333.T     | XTKS       | Food Products | Maruha Nichiro Corp.      |
+         |  3 | 2019-01-14 | 1352.T     | XTKS       | Food Retail   | Hohsui Corp.              |
+         |  4 | 2019-01-14 | 1376.T     | XTKS       | Farming       | Kaneko Seeds Co. Ltd.     |
+    === "Schema"
+        ```
+        {
+            date: str,
+            stock_id: str,
+            Exchange: str,
+            Sector: str,
+            stock_name: str
+        }
+        ```
+
+#### Japan Stock Price Table JapanStockPrice
+
+
+!!! example
+   ```python
+   import requests
+   import pandas as pd
+
+   url = 'https://api.finmindtrade.com/api/v4/data'
+   token = "" # Refer to the login page to obtain your API key
+   headers = {"Authorization": f"Bearer {token}"}
+   parameter = {
+      "dataset": "JapanStockPrice",
+      "data_id": "7203.T",
+      "start_date": "2020-06-16",
+      "end_date": "2021-06-16",
+   }
+   data = requests.get(url, headers=headers, params=parameter)
+   data = data.json()
+   data = pd.DataFrame(data['data'])
+   print(data.head())
+   ```
+!!! output
+    === "DataFrame"
+         |    | date       | stock_id   |   Adj_Close |   Close |   High |    Low |   Open |   Volume |
+         |---:|:-----------|:-----------|------------:|--------:|-------:|-------:|-------:|---------:|
+         |  0 | 2020-06-16 | 7203.T     |     1347.98 |  1404.2 | 1411.4 | 1368.6 | 1376   | 36452000 |
+         |  1 | 2020-06-17 | 7203.T     |     1333.2  |  1388.8 | 1401   | 1381   | 1400   | 23684000 |
+         |  2 | 2020-06-18 | 7203.T     |     1322.26 |  1377.4 | 1388   | 1368.6 | 1376   | 17525500 |
+         |  3 | 2020-06-19 | 7203.T     |     1315.35 |  1370.2 | 1382.4 | 1365   | 1381.6 | 29101500 |
+         |  4 | 2020-06-22 | 7203.T     |     1309.01 |  1363.6 | 1374   | 1356   | 1359.8 | 14133000 |
+    === "Schema"
+        ```
+        {
+            date: str,
+            stock_id: str,
+            Adj_Close: float32,
+            Close: float32,
+            High: float32,
+            Low: float32,
+            Open: float32,
+            Volume: int64
+        }
+        ```

--- a/docs/tutor/Materials.en.md
+++ b/docs/tutor/Materials.en.md
@@ -1,0 +1,87 @@
+In the commodities market, we offer 2 datasets, as follows:
+
+- [Gold Price Table GoldPrice](https://finmind.github.io/en/tutor/Materials/#goldprice)
+
+- [Crude Oil Price Table CrudeOilPrices](https://finmind.github.io/en/tutor/Materials/#crudeoilprices)
+
+In addition, the following list summarizes the available crude oil benchmarks. There are currently 2 of them.
+
+
+| data_id 	| Brent  	| WTI    	|
+|---------	|--------	|--------	|
+| Crude Oil 	| Brent 	| West Texas Intermediate 	|
+
+
+#### Gold Price Table GoldPrice
+
+!!! example
+     ```python
+     import requests
+     import pandas as pd
+
+     url = 'https://api.finmindtrade.com/api/v4/data'
+     token = "" # Refer to the login page to obtain your API key
+     headers = {"Authorization": f"Bearer {token}"}
+     parameter = {
+          "dataset": "GoldPrice",
+          "start_date": "2020-01-01",
+          "end_date": "2020-01-02",
+     }
+     data = requests.get(url, headers=headers, params=parameter)
+     data = data.json()
+     data = pd.DataFrame(data['data'])
+     print(data.head())
+
+     Price                 date
+     0  1517.2  2020-01-01 00:00:01
+     1  1517.2  2020-01-01 00:03:01
+     2  1517.2  2020-01-01 00:08:02
+     3  1517.2  2020-01-01 00:13:02
+     4  1517.2  2020-01-01 00:18:01
+     ```
+!!! output
+    === "Schema"
+        ```
+        {
+            Price: float32,
+            date: str
+        }
+        ```
+
+#### Crude Oil Price Table CrudeOilPrices
+
+!!! example
+     ```python
+     import requests
+     import pandas as pd
+
+     url = 'https://api.finmindtrade.com/api/v4/data'
+     token = "" # Refer to the login page to obtain your API key
+     headers = {"Authorization": f"Bearer {token}"}
+     parameter = {
+          "dataset": "CrudeOilPrices",
+          "data_id": "WTI",
+          "start_date": "2020-01-01",
+          "end_date": "2020-01-08",
+     }
+     data = requests.get(url, headers=headers, params=parameter)
+     data = data.json()
+     data = pd.DataFrame(data['data'])
+     print(data.head())
+
+          date name  price
+     0  2020-01-02  WTI  61.17
+     1  2020-01-03  WTI     63
+     2  2020-01-06  WTI  63.27
+     3  2020-01-07  WTI   62.7
+     4  2020-01-08  WTI  59.65
+     ```
+!!! output
+    === "Schema"
+        ```
+        {
+            date: str,
+            name: str,
+            price: float64
+        }
+        ```

--- a/docs/tutor/Others.en.md
+++ b/docs/tutor/Others.en.md
@@ -1,0 +1,38 @@
+
+
+#### CnnFearGreedIndex (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2011-01-03 ~ now
+
+!!! example
+    ```python
+    import requests
+    import pandas as pd
+
+    url = "https://api.finmindtrade.com/api/v4/data"
+    form_data = {
+        "dataset": "CnnFearGreedIndex",
+        "start_date": "2021-01-01",
+        "end_date": "2021-01-10",
+    }
+    res = requests.get(url, params=form_data)
+    temp = res.json()
+    data = pd.DataFrame(temp["data"])
+    print(data)
+    ```
+!!! output
+    === "DataFrame"
+        |    | date       |   fear_greed |   fear_greed_emotion |
+        |---:|:-----------|-------------:|---------------------:|
+        |  0 | 2021-01-04 |           53 |              neutral |
+        |  1 | 2021-01-05 |           52 |              neutral |
+        |  2 | 2021-01-06 |           59 |                greed |
+        |  3 | 2021-01-07 |           66 |                greed |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            fear_greed: int32, # fear and greed index
+            fear_greed_emotion: str # fear and greed emotion
+        }
+        ```

--- a/docs/tutor/TaiwanMarket/Chip.en.md
+++ b/docs/tutor/TaiwanMarket/Chip.en.md
@@ -1,0 +1,2781 @@
+In Taiwan stock chip data, we have 20 datasets as follows:
+
+
+- [Individual Stock Margin Purchase / Short Sale TaiwanStockMarginPurchaseShortSale](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockmarginpurchaseshortsale)
+- [Total Market Margin Purchase / Short Sale TaiwanStockTotalMarginPurchaseShortSale](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocktotalmarginpurchaseshortsale)
+- [Individual Stock Institutional Investors Buy/Sell TaiwanStockInstitutionalInvestorsBuySell](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockinstitutionalinvestorsbuysell)
+- [Total Market Institutional Investors Buy/Sell TaiwanStockTotalInstitutionalInvestors](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocktotalinstitutionalinvestors)
+- [Foreign Investor Shareholding TaiwanStockShareholding](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockshareholding)
+- [Shareholders Holding Shares Distribution TaiwanStockHoldingSharesPer](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockholdingsharesper-backersponsor)
+- [Securities Lending Transaction Details TaiwanStockSecuritiesLending](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocksecuritieslending)
+- [Margin Short Sale Suspension (Short Sale Covering Date) TaiwanStockMarginShortSaleSuspension](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockmarginshortsalesuspension)
+- [Credit Limit Daily Short Sale Balances TaiwanDailyShortSaleBalances](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwandailyshortsalebalances)
+- [Securities Trader Information TaiwanSecuritiesTraderInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwansecuritiestraderinfo)
+- [Taiwan Stock Trading Daily Report by Branch (query by stock_id) TaiwanStockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#query-by-taiwanstocktradingdailyreport-sponsor)
+- [Taiwan Stock Trading Daily Report by Branch (query by securities_trader_id) TaiwanStockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#query-by-taiwanstocktradingdailyreport-sponsor_1)
+- [Taiwan Stock Warrant Trading Daily Report by Branch (query by stock_id) TaiwanStockWarrantTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#query-by-taiwanstockwarranttradingdailyreport-sponsor)
+- [Taiwan Stock Warrant Trading Daily Report by Branch (query by securities_trader_id) TaiwanStockWarrantTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#query-by-taiwanstockwarranttradingdailyreport-sponsor_1)
+- [Taiwan Stock Government Bank Buy/Sell TaiwanstockGovernmentBankBuySell](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockgovernmentbankbuysell-sponsor)
+- [Taiwan Total Exchange Margin Maintenance TaiwanTotalExchangeMarginMaintenance](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwantotalexchangemarginmaintenance-backersponsor)
+- [Daily Securities Trader Branch Aggregate Statistics TaiwanStockTradingDailyReportSecIdAgg](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocktradingdailyreportsecidagg-sponsor)
+- [Block Trading Daily Report TaiwanStockBlockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockblocktradingdailyreport-sponsor)
+- [Block Trade Daily Transactions TaiwanStockBlockTrade](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockblocktrade-sponsor)
+- [Loan Collateral Balance TaiwanStockLoanCollateralBalance](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockloancollateralbalance-sponsor)
+- [Disposition Securities Period TaiwanStockDispositionSecuritiesPeriod](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdispositionsecuritiesperiod-backersponsor)
+- [Day Trading Borrowing Fee Rate TaiwanStockDayTradingBorrowingFeeRate](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdaytradingborrowingfeerate-backersponsor)
+
+
+----------------------------------
+#### Individual Stock Margin Purchase / Short Sale TaiwanStockMarginPurchaseShortSale
+
+- Data range: 2001-01-01 ~ now
+- Data update time **Monday to Friday 21:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_margin_purchase_short_sale(
+            stock_id="2330",
+            start_date='2020-04-02',
+            end_date='2020-04-12',
+        )
+        ```
+    === "Python"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMarginPurchaseShortSale",
+            "data_id": "2330",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMarginPurchaseShortSale",
+                data_id= "2330",
+                start_date= "2020-01-02",
+                end_date= "2020-04-12",
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_margin_purchase_short_sale(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   MarginPurchaseBuy |   MarginPurchaseCashRepayment |   MarginPurchaseLimit |   MarginPurchaseSell |   MarginPurchaseTodayBalance |   MarginPurchaseYesterdayBalance | Note   |   OffsetLoanAndShort |   ShortSaleBuy |   ShortSaleCashRepayment |   ShortSaleLimit |   ShortSaleSell |   ShortSaleTodayBalance |   ShortSaleYesterdayBalance |
+        |---:|:-----------|-----------:|--------------------:|------------------------------:|----------------------:|---------------------:|-----------------------------:|---------------------------------:|:-------|---------------------:|---------------:|-------------------------:|-----------------:|----------------:|------------------------:|----------------------------:|
+        |  0 | 2020-04-06 |       2330 |                1914 |                             8 |               6482595 |                 1269 |                        26285 |                            25648 | X      |                    0 |              0 |                       24 |          6482595 |               0 |                       0 |                          24 |
+        |  1 | 2020-04-07 |       2330 |                1049 |                            13 |               6482595 |                 2655 |                        24666 |                            26285 | X      |                    0 |              0 |                        0 |          6482595 |               0 |                       0 |                           0 |
+        |  2 | 2020-04-08 |       2330 |                1192 |                             3 |               6482595 |                 1569 |                        24286 |                            24666 |        |                    0 |              0 |                        0 |          6482595 |               0 |                       0 |                           0 |
+        |  3 | 2020-04-09 |       2330 |                 499 |                            28 |               6482595 |                 1362 |                        23395 |                            24286 |        |                  209 |              0 |                        0 |          6482595 |             398 |                     398 |                           0 |
+        |  4 | 2020-04-10 |       2330 |                1227 |                            24 |               6482595 |                  794 |                        23804 |                            23395 |        |                   53 |            156 |                        0 |          6482595 |             156 |                     398 |                         398 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            MarginPurchaseBuy: int64, # margin purchase buy
+            MarginPurchaseCashRepayment: int64, # margin purchase cash repayment
+            MarginPurchaseLimit: int64, # margin purchase limit
+            MarginPurchaseSell: int64, # margin purchase sell
+            MarginPurchaseTodayBalance: int64, # margin purchase today balance
+            MarginPurchaseYesterdayBalance: int64, # margin purchase yesterday balance
+            Note: str, # note
+            OffsetLoanAndShort: int64, # offset loan and short
+            ShortSaleBuy: int64, # short sale buy
+            ShortSaleCashRepayment: int64, # short sale cash repayment
+            ShortSaleLimit: int64, # short sale limit
+            ShortSaleSell: int64, # short sale sell
+            ShortSaleTodayBalance: int64, # short sale today balance
+            ShortSaleYesterdayBalance: int64 # short sale yesterday balance
+        }
+        ```
+
+#### Get all data for a specific date in one request (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_margin_purchase_short_sale(
+            start_date='2020-04-01',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMarginPurchaseShortSale",
+            "start_date": "2020-04-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMarginPurchaseShortSale",
+                start_date= "2020-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   MarginPurchaseBuy |   MarginPurchaseCashRepayment |   MarginPurchaseLimit |   MarginPurchaseSell |   MarginPurchaseTodayBalance |   MarginPurchaseYesterdayBalance | Note   |   OffsetLoanAndShort |   ShortSaleBuy |   ShortSaleCashRepayment |   ShortSaleLimit |   ShortSaleSell |   ShortSaleTodayBalance |   ShortSaleYesterdayBalance |
+        |---:|:-----------|-----------:|--------------------:|------------------------------:|----------------------:|---------------------:|-----------------------------:|---------------------------------:|:-------|---------------------:|---------------:|-------------------------:|-----------------:|----------------:|------------------------:|----------------------------:|
+        |  0 | 2020-04-01 |       0050 |                 193 |                            15 |                263750 |                  163 |                         3189 |                             3174 |        |                    0 |             65 |                        1 |           263750 |              13 |                    2283 |                        2336 |
+        |  1 | 2020-04-01 |       0051 |                   0 |                             0 |                  2375 |                    0 |                            5 |                                5 |        |                    0 |              0 |                        0 |             2375 |               0 |                       0 |                           0 |
+        |  2 | 2020-04-01 |       0052 |                   0 |                             0 |                  7500 |                    0 |                          128 |                              128 |        |                    0 |              0 |                        0 |             7500 |               0 |                       0 |                           0 |
+        |  3 | 2020-04-01 |       0053 |                   0 |                             0 |                  1622 |                    0 |                            1 |                                1 |        |                    0 |              0 |                        0 |             1622 |               0 |                       0 |                           0 |
+        |  4 | 2020-04-01 |       0054 |                   0 |                             0 |                  2531 |                    0 |                            0 |                                0 | X      |                    0 |              0 |                        0 |             2531 |               0 |                       0 |                           0 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            MarginPurchaseBuy: int64, # margin purchase buy
+            MarginPurchaseCashRepayment: int64, # margin purchase cash repayment
+            MarginPurchaseLimit: int64, # margin purchase limit
+            MarginPurchaseSell: int64, # margin purchase sell
+            MarginPurchaseTodayBalance: int64, # margin purchase today balance
+            MarginPurchaseYesterdayBalance: int64, # margin purchase yesterday balance
+            Note: str, # note
+            OffsetLoanAndShort: int64, # offset loan and short
+            ShortSaleBuy: int64, # short sale buy
+            ShortSaleCashRepayment: int64, # short sale cash repayment
+            ShortSaleLimit: int64, # short sale limit
+            ShortSaleSell: int64, # short sale sell
+            ShortSaleTodayBalance: int64, # short sale today balance
+            ShortSaleYesterdayBalance: int64 # short sale yesterday balance
+        }
+        ```
+
+----------------------------------
+#### Taiwan Total Market Margin Purchase / Short Sale TaiwanStockTotalMarginPurchaseShortSale
+
+- Data range: 2001-01-01 ~ now
+- Data update time **Monday to Friday 21:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_margin_purchase_short_sale_total(
+            start_date='2020-04-01',
+            end_date='2020-04-12',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockTotalMarginPurchaseShortSale",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockTotalMarginPurchaseShortSale",
+                start_date= "2020-01-02",
+                end_date= "2020-04-12"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   TodayBalance |   YesBalance |        buy | date       | name                |    Return |       sell |
+        |---:|---------------:|-------------:|-----------:|:-----------|:--------------------|----------:|-----------:|
+        |  0 |        5463820 |      5471770 |     236127 | 2020-04-01 | MarginPurchase      |     10986 |     233091 |
+        |  1 |    91965082000 |  91898116000 | 4046643000 | 2020-04-01 | MarginPurchaseMoney | 196619000 | 3783058000 |
+        |  2 |         541704 |       556742 |      57266 | 2020-04-01 | ShortSale           |      6151 |      48379 |
+        |  3 |         535401 |       541704 |      50779 | 2020-04-06 | ShortSale           |      3700 |      48176 |
+        |  4 |    93198509000 |  91965082000 | 6440842000 | 2020-04-06 | MarginPurchaseMoney |  71638000 | 5135777000 |
+    === "Schema"
+        ```
+        {
+            TodayBalance: int64, # today balance
+            YesBalance: int64, # yesterday balance
+            buy: int64, # buy
+            date: str, # date
+            name: str, # category
+            Return: int64, # cash/securities repayment
+            sell: int64 # sell
+        }
+        ```
+
+----------------------------------
+#### Institutional Investors Buy/Sell TaiwanStockInstitutionalInvestorsBuySell
+
+- Data range: 2005-01-01 ~ now
+- Data update time **Monday to Friday 20:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_institutional_investors(
+            stock_id="2330",
+            start_date='2020-04-01',
+            end_date='2020-04-12',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockInstitutionalInvestorsBuySell",
+            "data_id": "2330",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockInstitutionalInvestorsBuySell",
+                data_id= "2330",
+                start_date= "2020-04-01",
+                end_date= "2020-04-12"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_institutional_investors(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |      buy | name                |     sell |
+        |---:|:-----------|-----------:|---------:|:--------------------|---------:|
+        |  0 | 2020-04-01 |       2330 | 31304729 | Foreign_Investor    | 29057663 |
+        |  1 | 2020-04-01 |       2330 |        0 | Foreign_Dealer_Self |        0 |
+        |  2 | 2020-04-01 |       2330 |   900000 | Investment_Trust    |   239000 |
+        |  3 | 2020-04-01 |       2330 |    79000 | Dealer_self         |   807000 |
+        |  4 | 2020-04-01 |       2330 |   189000 | Dealer_Hedging      |   493500
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            buy: int64, # buy
+            name: str, # category
+            sell: int64 # sell
+        }
+        ```
+
+#### Get all data for a specific date in one request (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_institutional_investors(
+            start_date='2020-04-01',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockInstitutionalInvestorsBuySell",
+            "start_date": "2020-04-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockInstitutionalInvestorsBuySell",
+                start_date= "2020-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |     buy | name                |    sell |
+        |---:|:-----------|-----------:|--------:|:--------------------|--------:|
+        |  0 | 2020-04-01 |       0050 |  458249 | Foreign_Investor    | 4492000 |
+        |  1 | 2020-04-01 |       0050 |       0 | Foreign_Dealer_Self |       0 |
+        |  2 | 2020-04-01 |       0050 |   54000 | Investment_Trust    |       0 |
+        |  3 | 2020-04-01 |       0050 |       0 | Dealer_self         |       0 |
+        |  4 | 2020-04-01 |       0050 | 2050000 | Dealer_Hedging      |  905000 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            buy: int64, # buy
+            name: str, # category
+            sell: int64 # sell
+        }
+        ```
+
+----------------------------------
+#### Taiwan Total Market Institutional Investors Buy/Sell TaiwanStockTotalInstitutionalInvestors
+
+- Data range: 2004-04-01 ~ now
+- Data update time **Monday to Friday 15:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_institutional_investors_total(
+            start_date='2020-04-01',
+            end_date='2020-04-12',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockTotalInstitutionalInvestors",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockTotalInstitutionalInvestors",
+                start_date= "2020-01-02",
+                end_date='2020-04-12'
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |         buy | date       | name                |        sell |
+        |---:|------------:|:-----------|:--------------------|------------:|
+        |  0 |      123150 | 2020-04-01 | Foreign_Dealer_Self |      266220 |
+        |  1 |  3681729831 | 2020-04-01 | Dealer_Hedging      |  5539788946 |
+        |  2 | 33759089839 | 2020-04-01 | Foreign_Investor    | 38466572585 |
+        |  3 |  3039112340 | 2020-04-01 | Investment_Trust    |   853138940 |
+        |  4 |   789316840 | 2020-04-01 | Dealer_self         |   912143500 |
+    === "Schema"
+        ```
+        {
+            buy: int64, # buy
+            date: str, # date
+            name: str, # category
+            sell: int64 # sell
+        }
+        ```
+
+----------------------------------
+#### Foreign Investor Shareholding TaiwanStockShareholding
+
+- Data range: 2004-02-01 ~ now
+- Data update time **Monday to Friday 21:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_shareholding(
+            stock_id="2330",
+            start_date='2020-04-01',
+            end_date='2020-04-12'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockShareholding",
+            "data_id": "2330",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockShareholding",
+                data_id= "2330",
+                start_date= "2020-01-02",
+                end_date="2020-04-12"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_shareholding(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | stock_name   | InternationalCode   |   ForeignInvestmentRemainingShares |   ForeignInvestmentShares |   ForeignInvestmentRemainRatio |   ForeignInvestmentSharesRatio |   ForeignInvestmentUpperLimitRatio |   ChineseInvestmentUpperLimitRatio |   NumberOfSharesIssued | RecentlyDeclareDate   | note   |
+        |---:|:-----------|-----------:|:-------------|:--------------------|-----------------------------------:|--------------------------:|-------------------------------:|-------------------------------:|-----------------------------------:|-----------------------------------:|-----------------------:|:----------------------|:-------|
+        |  0 | 2020-04-01 |       2330 | 台積電       | TW0002330008        |                         6309042842 |               19621337616 |                          24.33 |                          75.66 |                                100 |                                100 |            25930380458 | 2019-05-27            |        |
+        |  1 | 2020-04-06 |       2330 | 台積電       | TW0002330008        |                         6304552683 |               19625827775 |                          24.31 |                          75.68 |                                100 |                                100 |            25930380458 | 2019-05-27            |        |
+        |  2 | 2020-04-07 |       2330 | 台積電       | TW0002330008        |                         6283562246 |               19646818212 |                          24.23 |                          75.76 |                                100 |                                100 |            25930380458 | 2019-05-27            |        |
+        |  3 | 2020-04-08 |       2330 | 台積電       | TW0002330008        |                         6273338931 |               19657041527 |                          24.19 |                          75.8  |                                100 |                                100 |            25930380458 | 2019-05-27            |        |
+        |  4 | 2020-04-09 |       2330 | 台積電       | TW0002330008        |                         6267988722 |               19662391736 |                          24.17 |                          75.82 |                                100 |                                100 |            25930380458 | 2019-05-27            |        |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            stock_name: str, # stock name
+            InternationalCode: str, # international stock code
+            ForeignInvestmentRemainingShares: int64, # remaining shares available for foreign investment
+            ForeignInvestmentShares: int64, # shares held by foreign investors
+            ForeignInvestmentRemainRatio: float64, # ratio of shares available for foreign investment
+            ForeignInvestmentSharesRatio: float64, # foreign shareholding ratio
+            ForeignInvestmentUpperLimitRatio: float64, # foreign investment upper limit
+            ChineseInvestmentUpperLimitRatio: float64, # mainland Chinese investment upper limit
+            NumberOfSharesIssued: int64, # number of shares issued
+            RecentlyDeclareDate: str, # most recent declaration date
+            note: str # note
+        }
+        ```
+
+#### Get all data for a specific date in one request (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_shareholding(
+            start_date='2020-04-01',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockShareholding",
+            "start_date": "2020-04-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockShareholding",
+                start_date= "2020-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | stock_name   | InternationalCode   |   ForeignInvestmentRemainingShares |   ForeignInvestmentShares |   ForeignInvestmentRemainRatio |   ForeignInvestmentSharesRatio |   ForeignInvestmentUpperLimitRatio |   ChineseInvestmentUpperLimitRatio |   NumberOfSharesIssued | RecentlyDeclareDate   | note   |
+        |---:|:-----------|-----------:|:-------------|:--------------------|-----------------------------------:|--------------------------:|-------------------------------:|-------------------------------:|-----------------------------------:|-----------------------------------:|-----------------------:|:----------------------|:-------|
+        |  0 | 2020-04-01 |       0050 | 元大台灣50   | TW0000050004        |                          960256795 |                  94743205 |                          91.01 |                           8.98 |                                100 |                                100 |             1055000000 | 2019-07-18            |        |
+        |  1 | 2020-04-01 |       0051 | 元大中型100  | TW0000051002        |                            9471000 |                     29000 |                          99.69 |                           0.3  |                                100 |                                100 |                9500000 | 2019-07-18            |        |
+        |  2 | 2020-04-01 |       0052 | 富邦科技     | TW0000052000        |                           29957000 |                     43000 |                          99.85 |                           0.14 |                                100 |                                100 |               30000000 | 2019-07-18            |        |
+        |  3 | 2020-04-01 |       0053 | 元大電子     | TW0000053008        |                            6466950 |                     21050 |                          99.67 |                           0.32 |                                100 |                                100 |                6488000 | 2019-07-18            |        |
+        |  4 | 2020-04-01 |       0054 | 元大台商50   | TW0000054006        |                            9955000 |                    169000 |                          98.33 |                           1.66 |                                100 |                                100 |               10124000 | 2019-07-18            |        |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            stock_name: str, # stock name
+            InternationalCode: str, # international stock code
+            ForeignInvestmentRemainingShares: int64, # remaining shares available for foreign investment
+            ForeignInvestmentShares: int64, # shares held by foreign investors
+            ForeignInvestmentRemainRatio: float64, # ratio of shares available for foreign investment
+            ForeignInvestmentSharesRatio: float64, # foreign shareholding ratio
+            ForeignInvestmentUpperLimitRatio: float64, # foreign investment upper limit
+            ChineseInvestmentUpperLimitRatio: float64, # mainland Chinese investment upper limit
+            NumberOfSharesIssued: int64, # number of shares issued
+            RecentlyDeclareDate: str, # most recent declaration date
+            note: str # note
+        }
+        ```
+
+----------------------------------
+#### Shareholders Holding Shares Distribution TaiwanStockHoldingSharesPer (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2010-01-29 ~ now
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_holding_shares_per(
+            stock_id="2330",
+            start_date='2020-04-01',
+            end_date='2020-04-12'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockHoldingSharesPer",
+            "data_id": "2330",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockHoldingSharesPer",
+                data_id= "2330",
+                start_date= "2020-01-02",
+                end_date='2020-04-12'
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_holding_shares_per(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | HoldingSharesLevel   |   people |   percent |      unit |
+        |---:|:-----------|-----------:|:---------------------|---------:|----------:|----------:|
+        |  0 | 2020-04-01 |       2330 | 1-999                |   165122 |      0.12 |  33289900 |
+        |  1 | 2020-04-01 |       2330 | 1000-5000            |   227692 |      1.69 | 440404454 |
+        |  2 | 2020-04-01 |       2330 | 10001-15000          |    10408 |      0.49 | 128127693 |
+        |  3 | 2020-04-01 |       2330 | 100001-200000        |     1628 |      0.86 | 225202876 |
+        |  4 | 2020-04-01 |       2330 | 15001-20000          |     5068 |      0.34 |  89929303 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            HoldingSharesLevel: str, # shareholding level
+            people: int64, # number of people
+            percent: float64, # ratio
+            unit: int64 # number of shares
+        }
+        ```
+
+#### Get all data for a specific date in one request (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_holding_shares_per(
+            start_date='2020-04-01',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockHoldingSharesPer",
+            "start_date": "2020-04-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockHoldingSharesPer",
+                start_date= "2020-04-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | HoldingSharesLevel   |   people |   percent |      unit |
+        |---:|:-----------|-----------:|:---------------------|---------:|----------:|----------:|
+        |  0 | 2020-04-01 |       0050 | 1-999                |    44173 |      1.02 |  10834763 |
+        |  1 | 2020-04-01 |       0050 | 1000-5000            |    96465 |     17.7  | 186791648 |
+        |  2 | 2020-04-01 |       0050 | 5001-10000           |    10364 |      7.57 |  79902735 |
+        |  3 | 2020-04-01 |       0050 | 10001-15000          |     2819 |      3.41 |  36075583 |
+        |  4 | 2020-04-01 |       0050 | 15001-20000          |     1557 |      2.69 |  28426726 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            HoldingSharesLevel: str, # shareholding level
+            people: int64, # number of people
+            percent: float64, # ratio
+            unit: int64 # number of shares
+        }
+        ```
+
+----------------------------------
+#### Securities Lending Transaction Details TaiwanStockSecuritiesLending
+
+- Data range: 2001-05-01 ~ now
+- Data update time **Monday to Friday 15:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_securities_lending(
+            stock_id="2330",
+            start_date='2020-04-01',
+            end_date='2020-04-12'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockSecuritiesLending",
+            "data_id": "2330",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+        url = url,
+            query = list(
+                dataset="TaiwanStockSecuritiesLending",
+                data_id="2330",
+                start_date= "2020-01-02",
+                end_date='2020-04-12'
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_securities_lending(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | transaction_type   |   volume |   fee_rate |   close | original_return_date   |   original_lending_period |
+        |---:|:-----------|-----------:|:-------------------|---------:|-----------:|--------:|:-----------------------|--------------------------:|
+        |  0 | 2020-04-01 |       2330 | 議借               |     1330 |       1.36 |   271.5 | 2020-09-30             |                       182 |
+        |  1 | 2020-04-01 |       2330 | 議借               |      800 |       0.41 |   271.5 | 2020-09-30             |                       182 |
+        |  2 | 2020-04-01 |       2330 | 議借               |      850 |       0.41 |   271.5 | 2020-09-30             |                       182 |
+        |  3 | 2020-04-01 |       2330 | 議借               |      500 |       0.5  |   271.5 | 2020-09-30             |                       182 |
+        |  4 | 2020-04-01 |       2330 | 議借               |      160 |       0.36 |   271.5 | 2020-09-30             |                       182 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            transaction_type: str, # transaction type
+            volume: int64, # transaction volume
+            fee_rate: float64, # transaction fee rate
+            close: float64, # closing price
+            original_return_date: str, # agreed return date
+            original_lending_period: int64 # agreed lending period (days)
+        }
+        ```
+
+#### Get all data for a specific date in one request (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_securities_lending(
+            start_date='2020-04-01',
+        )
+        ```
+    === "Python"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockSecuritiesLending",
+            "start_date": "2020-04-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockSecuritiesLending",
+                start_date= "2020-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | transaction_type   |   volume |   fee_rate |   close | original_return_date   |   original_lending_period |
+        |---:|:-----------|-----------:|:-------------------|---------:|-----------:|--------:|:-----------------------|--------------------------:|
+        |  0 | 2020-04-01 |       1101 | 議借               |      760 |       0.25 |    39   | 2020-09-30             |                       182 |
+        |  1 | 2020-04-01 |       1101 | 議借               |      397 |       0.25 |    39   | 2020-09-30             |                       182 |
+        |  2 | 2020-04-01 |       1101 | 競價               |      436 |       0.7  |    39   | 2020-09-30             |                       182 |
+        |  3 | 2020-04-01 |       1102 | 議借               |      150 |       0.25 |    38.6 | 2020-09-30             |                       182 |
+        |  4 | 2020-04-01 |       1102 | 議借               |      770 |       1.05 |    38.6 | 2020-09-30             |                       182 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            transaction_type: str, # transaction type
+            volume: int64, # transaction volume
+            fee_rate: float64, # transaction fee rate
+            close: float64, # closing price
+            original_return_date: str, # agreed return date
+            original_lending_period: int64 # agreed lending period (days)
+        }
+        ```
+
+
+----------------------------------
+#### Margin Short Sale Suspension (Short Sale Covering Date) TaiwanStockMarginShortSaleSuspension
+
+- Data range: 2015-01-01 ~ now
+- Data update time **Monday to Friday 21:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMarginShortSaleSuspension",
+            "data_id": "0050",
+            "start_date": "2015-01-01",
+            "end_date": "2015-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMarginShortSaleSuspension",
+                data_id="0050",
+                start_date= "2015-01-01",
+                end_date= "2015-04-12"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_margin_short_sale_suspension(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    |   stock_id | date       | end_date   | reason   |
+        |---:|-----------:|:-----------|:-----------|:---------|
+        |  0 |       0050 | 2015-10-20 | 2015-10-23 | 分配收益 |
+        |  1 |       0050 | 2016-07-22 | 2016-07-27 | 分配收益 |
+        |  2 |       0050 | 2017-02-02 | 2017-02-07 | 分配收益 |
+        |  3 |       0050 | 2017-07-25 | 2017-07-28 | 分配收益 |
+        |  4 |       0050 | 2018-01-23 | 2018-01-26 | 分配收益 |
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock symbol
+            date: str, # start date
+            end_date: str, # end date
+            reason: str # suspension reason
+        }
+        ```
+
+#### Get all data for a specific date in one request (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMarginShortSaleSuspension",
+            "start_date": "2015-10-20",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMarginShortSaleSuspension",
+                start_date= "2015-10-20"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   stock_id | date       | end_date   | reason   |
+        |---:|-----------:|:-----------|:-----------|:---------|
+        |  0 |       0050 | 2015-10-20 | 2015-10-23 | 分配收益 |
+        |  1 |       0056 | 2015-10-20 | 2015-10-23 | 分配收益 |
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock symbol
+            date: str, # start date
+            end_date: str, # end date
+            reason: str # suspension reason
+        }
+        ```
+
+
+----------------------------------
+#### Credit Limit Daily Short Sale Balances TaiwanDailyShortSaleBalances
+
+- Data range: 2005-07-01 ~ now
+- Data update time **Monday to Friday 21:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_daily_short_sale_balances(
+            stock_id="2330",
+            start_date='2020-04-01',
+            end_date='2020-04-12',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanDailyShortSaleBalances",
+            "data_id": "2330",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+        url = url,
+            query = list(
+                dataset="TaiwanDailyShortSaleBalances",
+                data_id="2330",
+                start_date= "2020-01-02",
+                end_date='2020-04-12'
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_daily_short_sale_balances(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    |   stock_id |   MarginShortSalesPreviousDayBalance |   MarginShortSalesShortSales |   MarginShortSalesShortCovering |   MarginShortSalesStockRedemption |   MarginShortSalesCurrentDayBalance |   MarginShortSalesQuota |   SBLShortSalesPreviousDayBalance |   SBLShortSalesShortSales |   SBLShortSalesReturns |   SBLShortSalesAdjustments |   SBLShortSalesCurrentDayBalance |   SBLShortSalesQuota |   SBLShortSalesShortCovering | date       |
+        |---:|-----------:|-------------------------------------:|-----------------------------:|--------------------------------:|----------------------------------:|------------------------------------:|------------------------:|----------------------------------:|--------------------------:|-----------------------:|---------------------------:|---------------------------------:|---------------------:|-----------------------------:|:-----------|
+        |  0 |       2330 |                              1975000 |                            0 |                         1573000 |                            378000 |                               24000 |             -2107339478 |                          47947858 |                    487000 |                      0 |                          0 |                         48434858 |              7526895 |                            0 | 2020-04-01 |
+        |  1 |       2330 |                                24000 |                            0 |                               0 |                             24000 |                                   0 |             -2107339478 |                          48434858 |                     44000 |                  60000 |                          0 |                         48418858 |              7563083 |                            0 | 2020-04-06 |
+        |  2 |       2330 |                                    0 |                            0 |                               0 |                                 0 |                                   0 |             -2107339478 |                          48418858 |                     62000 |                      0 |                          0 |                         48480858 |              7635835 |                            0 | 2020-04-07 |
+        |  3 |       2330 |                                    0 |                            0 |                               0 |                                 0 |                                   0 |             -2107339478 |                          48480858 |                    933000 |                7345000 |                          0 |                         42068858 |              7688249 |                            0 | 2020-04-08 |
+        |  4 |       2330 |                                    0 |                       398000 |                               0 |                                 0 |                              398000 |             -2107339478 |                          42068858 |                     46000 |                   2000 |                          0 |                         42112858 |              7642682 |                            0 | 2020-04-09 |
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock symbol
+            MarginShortSalesPreviousDayBalance: int32, # previous day balance (margin short sales)
+            MarginShortSalesShortSales: int32, # sell (margin short sales)
+            MarginShortSalesShortCovering: int32, # buy (margin short sales)
+            MarginShortSalesStockRedemption: int32, # stock redemption (margin short sales)
+            MarginShortSalesCurrentDayBalance: int32, # current day balance (margin short sales)
+            MarginShortSalesQuota: int32, # quota (margin short sales)
+            SBLShortSalesPreviousDayBalance: int32, # previous day balance (SBL short sales)
+            SBLShortSalesShortSales: int32, # sell (SBL short sales)
+            SBLShortSalesReturns: int32, # returns (SBL short sales)
+            SBLShortSalesAdjustments: int32, # current day adjustment (SBL short sales)
+            SBLShortSalesCurrentDayBalance: int32, # current day balance (SBL short sales)
+            SBLShortSalesQuota: int32, # quota (SBL short sales)
+            SBLShortSalesShortCovering: int32, # inventory adjustment (SBL short sales)
+            date: str # date
+        }
+        ```
+
+#### Get all data for a specific date in one request (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_daily_short_sale_balances(
+            start_date='2020-04-01',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanDailyShortSaleBalances",
+            "start_date": "2021-05-20",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+        url = url,
+            query = list(
+                dataset="TaiwanDailyShortSaleBalances",
+                start_date= "2020-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   stock_id |   MarginShortSalesPreviousDayBalance |   MarginShortSalesShortSales |   MarginShortSalesShortCovering |   MarginShortSalesStockRedemption |   MarginShortSalesCurrentDayBalance |   MarginShortSalesQuota |   SBLShortSalesPreviousDayBalance |   SBLShortSalesShortSales |   SBLShortSalesReturns |   SBLShortSalesAdjustments |   SBLShortSalesCurrentDayBalance |   SBLShortSalesQuota |   SBLShortSalesShortCovering | date       |
+        |---:|-----------:|-------------------------------------:|-----------------------------:|--------------------------------:|----------------------------------:|------------------------------------:|------------------------:|----------------------------------:|--------------------------:|-----------------------:|---------------------------:|---------------------------------:|---------------------:|-----------------------------:|:-----------|
+        |  0 |       0050 |                              2336000 |                        13000 |                           65000 |                              1000 |                             2283000 |               263750000 |                          25527000 |                         0 |                      0 |                          0 |                         25527000 |              2397551 |                            0 | 2020-04-01 |
+        |  1 |       0051 |                                    0 |                            0 |                               0 |                                 0 |                                   0 |                 2375000 |                              1000 |                         0 |                      0 |                          0 |                             1000 |                 4053 |                            0 | 2020-04-01 |
+        |  2 |       0052 |                                    0 |                            0 |                               0 |                                 0 |                                   0 |                 7500000 |                             34000 |                         0 |                      0 |                          0 |                            34000 |                17168 |                            0 | 2020-04-01 |
+        |  3 |       0053 |                                    0 |                            0 |                               0 |                                 0 |                                   0 |                 1622000 |                                 0 |                         0 |                      0 |                          0 |                                0 |                 3158 |                            0 | 2020-04-01 |
+        |  4 |       0054 |                                    0 |                            0 |                               0 |                                 0 |                                   0 |                 2531000 |                                 0 |                         0 |                      0 |                          0 |                                0 |                 1357 |                            0 | 2020-04-01 |
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock symbol
+            MarginShortSalesPreviousDayBalance: int32, # previous day balance (margin short sales)
+            MarginShortSalesShortSales: int32, # sell (margin short sales)
+            MarginShortSalesShortCovering: int32, # buy (margin short sales)
+            MarginShortSalesStockRedemption: int32, # stock redemption (margin short sales)
+            MarginShortSalesCurrentDayBalance: int32, # current day balance (margin short sales)
+            MarginShortSalesQuota: int32, # quota (margin short sales)
+            SBLShortSalesPreviousDayBalance: int32, # previous day balance (SBL short sales)
+            SBLShortSalesShortSales: int32, # sell (SBL short sales)
+            SBLShortSalesReturns: int32, # returns (SBL short sales)
+            SBLShortSalesAdjustments: int32, # current day adjustment (SBL short sales)
+            SBLShortSalesCurrentDayBalance: int32, # current day balance (SBL short sales)
+            SBLShortSalesQuota: int32, # quota (SBL short sales)
+            SBLShortSalesShortCovering: int32, # inventory adjustment (SBL short sales)
+            date: str # date
+        }
+        ```
+
+----------------------------------
+#### Securities Trader Information TaiwanSecuritiesTraderInfo
+
+- Provides securities trader related information, used with the Taiwan Stock Trading Daily Report by Branch (TaiwanStockTradingDailyReport). Use the securities_trader_id to query all stock transactions of a particular securities trader.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_securities_trader_info()
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanSecuritiesTraderInfo",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset = "TaiwanSecuritiesTraderInfo"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    |   securities_trader_id | securities_trader   | date       | address                                                                                      | phone       |
+        |---:|-----------------------:|:--------------------|:-----------|:---------------------------------------------------------------------------------------------|:------------|
+        |  0 |                   1020 | 合庫                | 2011-12-02 | 台北市大安區忠孝東路四段325號2樓(部分)、經紀部複委託科地址：台北市松山區長安東路二段225號5樓 | 02-27528000 |
+        |  1 |                   1021 | 合庫- 台中          | 2011-12-02 | 台中市西區民權路91號6樓                                                                      | 04-22255141 |
+        |  2 |                   1022 | 合庫-台南           | 2011-12-02 | 台南市北區成功路48號3樓                                                                      | 06-2260148  |
+        |  3 |                   1023 | 合庫-高雄           | 2011-12-02 | 高雄市大勇路97號5樓                                                                          | 07-5319755  |
+        |  4 |                   1024 | 合庫-嘉義           | 2011-12-02 | 嘉義市國華街279號2樓                                                                         | 05-2220016  |
+    === "Schema"
+        ```
+        {
+            securities_trader_id: str, # securities trader code
+            securities_trader: str, # securities trader name
+            date: str, # opening date
+            address: str, # address
+            phone: str # phone
+        }
+        ```
+
+----------------------------------
+#### Taiwan Stock Trading Daily Report by Branch (query by stock_id) TaiwanStockTradingDailyReport (only available for [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Provides Taiwan stock trading by branch information for listed (TWSE), OTC, and emerging stocks!
+- Data range: 2021-06-30 ~ now
+- Due to the large data volume, only one day of data is provided per request.
+- Data update time **Monday to Friday 21:00**, the actual update time is based on the API data.
+- Some data is missing on the following dates: 2022-10-31~2022-11-03, 2023-01-11~2023-01-17.
+- Enabling Async can significantly reduce data fetch time. In Colab tests, downloading 2,175 stocks takes only 4 minutes 20 seconds.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_trading_daily_report(
+            stock_id="2330",
+            date='2022-06-16',
+        )
+        print(df)
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        token = ""
+
+        data_loader = DataLoader()
+        data_loader.login_by_token(token)
+
+        date = "2025-12-08"
+        start = datetime.datetime.now()
+        df = data_loader.taiwan_stock_trading_daily_report(
+            date=date,
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        # 0:04:20
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+
+        url = 'https://api.finmindtrade.com/api/v4/taiwan_stock_trading_daily_report'
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "data_id": "2330",
+            "date": "2022-06-16",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the API key
+        url = 'https://api.finmindtrade.com/api/v4/taiwan_stock_trading_daily_report'
+        response = httr::GET(
+            url = url,
+            query = list(
+                data_id="2330",
+                start_date= "2022-06-16",
+                token = token # Refer to login to obtain the API key
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | securities_trader   |   price |   buy |   sell |   securities_trader_id |   stock_id | date       |
+        |---:|:--------------------|--------:|------:|-------:|-----------------------:|-----------:|:-----------|
+        |  0 | 合庫                |     508 |  4000 |   2000 |                   1020 |       2330 | 2022-06-16 |
+        |  1 | 合庫                |     509 |  3480 |      0 |                   1020 |       2330 | 2022-06-16 |
+        |  2 | 合庫                |     510 |  2310 |     50 |                   1020 |       2330 | 2022-06-16 |
+        |  3 | 合庫                |     511 |  1169 |      0 |                   1020 |       2330 | 2022-06-16 |
+        |  4 | 合庫                |     512 |  1300 |  10000 |                   1020 |       2330 | 2022-06-16 |
+    === "Schema"
+        ```
+        {
+            securities_trader: str, # securities trader name
+            price: float64, # transaction price
+            buy: int32, # shares bought
+            sell: int32, # shares sold
+            securities_trader_id: str, # securities trader code
+            stock_id: str, # stock symbol
+            date: str # date
+        }
+        ```
+
+----------------------------------
+#### Taiwan Stock Trading Daily Report by Branch (query by securities_trader_id) TaiwanStockTradingDailyReport (only available for [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Provides Taiwan stock trading by branch information for listed (TWSE), OTC, and emerging stocks!
+- Data range: 2021-06-30 ~ now
+- Due to the large data volume, only one day of data is provided per request.
+- Data update time **Monday to Friday 21:00**, the actual update time is based on the API data.
+- Some data is missing on the following dates: 2022-10-31~2022-11-03, 2023-01-11~2023-01-17.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_trading_daily_report(
+            securities_trader_id="1102",
+            date='2022-06-16',
+        )
+        print(df)
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        url = 'https://api.finmindtrade.com/api/v4/taiwan_stock_trading_daily_report'
+        parameter = {
+            "securities_trader_id": "1020",
+            "date": "2022-06-16",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the API key
+        url = 'https://api.finmindtrade.com/api/v4/taiwan_stock_trading_daily_report'
+        response = httr::GET(
+            url = url,
+            query = list(
+                securities_trader_id="1020",
+                start_date= "2022-06-16",
+                token = token # Refer to login to obtain the API key
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |      | securities_trader   |   price |   buy |   sell |   securities_trader_id |   stock_id | date       |
+        |-----:|:--------------------|--------:|------:|-------:|-----------------------:|-----------:|:-----------|
+        |    0 | 合庫                |  122.25 | 19000 |      0 |                   1020 |       0050 | 2022-06-16 |
+        |    1 | 合庫                |  122.3  | 80000 |      0 |                   1020 |       0050 | 2022-06-16 |
+        |    2 | 合庫                |  122.35 | 10000 |      0 |                   1020 |       0050 | 2022-06-16 |
+        |    3 | 合庫                |  122.5  |  1300 |      0 |                   1020 |       0050 | 2022-06-16 |
+        |    4 | 合庫                |  122.55 | 20000 |      0 |                   1020 |       0050 | 2022-06-16 |
+        |  ... | ...                 |  ...    | ...   |   ... |                   ...   |       ...  | ...        |
+        | 3211 | 合庫                |  107    |  1000 |  50000 |                   1020 |       9958 | 2022-06-16 |
+        | 3212 | 合庫                |  107.5  |     0 |  32000 |                   1020 |       9958 | 2022-06-16 |
+        | 3213 | 合庫                |  108    |     0 |   2000 |                   1020 |       9958 | 2022-06-16 |
+        | 3214 | 合庫                |  108.5  |   150 |      0 |                   1020 |       9958 | 2022-06-16 |
+        | 3215 | 合庫                |   16.05 |  1000 |      0 |                   1020 |       9962 | 2022-06-16 |
+    === "Schema"
+        ```
+        {
+            securities_trader: str, # securities trader name
+            price: float64, # transaction price
+            buy: int32, # shares bought
+            sell: int32, # shares sold
+            securities_trader_id: str, # securities trader code
+            stock_id: str, # stock symbol
+            date: str # date
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [sponsorpro](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+(Due to the large data volume, each request only provides one day's data.)
+
+- Data range: 2021-06-30 ~ now.
+- Providing the dataset and date parameters returns the branch-level trading data of all stocks for that day.
+- Downloads the whole-day parquet via a signed URL, avoiding file-by-file queries — suitable for batch analysis covering the entire market.
+- Data update time: **Monday to Friday 21:00**. The actual update time is based on the API data.
+- Some data is missing on these dates: 2022-10-31~2022-11-03, 2023-01-11~2023-01-17.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_trading_daily_report(
+            date='2022-06-16',
+            use_object=True,
+        )
+        ```
+    === "Python-request"
+        ```python
+        import io
+        import requests
+        import pandas as pd
+
+        url = "https://api.finmindtrade.com/api/v4/storage_objects"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockTradingDailyReport",
+            "date": "2022-06-16",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = pd.read_parquet(io.BytesIO(resp.content))
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        library(arrow)
+
+        url = 'https://api.finmindtrade.com/api/v4/storage_objects'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockTradingDailyReport",
+                date= "2022-06-16"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        con = content(response, "raw")
+        data <- read_parquet(con)
+        close(con)
+        head(data)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | securities_trader   |   price |   buy |   sell |   securities_trader_id |   stock_id | date       |
+        |---:|:--------------------|--------:|------:|-------:|-----------------------:|-----------:|:-----------|
+        |  0 | 合庫                |     508 |  4000 |   2000 |                   1020 |       2330 | 2022-06-16 |
+        |  1 | 合庫                |     509 |  3480 |      0 |                   1020 |       2330 | 2022-06-16 |
+        |  2 | 合庫                |     510 |  2310 |     50 |                   1020 |       2330 | 2022-06-16 |
+        |  3 | 合庫                |     511 |  1169 |      0 |                   1020 |       2330 | 2022-06-16 |
+        |  4 | 合庫                |     512 |  1300 |  10000 |                   1020 |       2330 | 2022-06-16 |
+    === "Schema"
+        ```
+        {
+            securities_trader: str, # securities trader name
+            price: float64, # deal price
+            buy: int32, # shares bought
+            sell: int32, # shares sold
+            securities_trader_id: str, # securities trader code
+            stock_id: str, # stock symbol
+            date: str # date
+        }
+        ```
+
+----------------------------------
+#### Taiwan Stock Warrant Trading Daily Report by Branch (query by stock_id) TaiwanStockWarrantTradingDailyReport (only available for [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2023-06-21 ~ now
+- Due to the large data volume, only one day of data is provided per request.
+- Data update time **Monday to Friday 01:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_warrant_trading_daily_report(
+            stock_id="084655",
+            date='2023-06-21',
+        )
+        print(df)
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        url = 'https://api.finmindtrade.com/api/v4/taiwan_stock_warrant_trading_daily_report'
+        parameter = {
+            "data_id": "084655",
+            "date": "2023-06-21",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/taiwan_stock_warrant_trading_daily_report'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                data_id="084655",
+                start_date= "2023-06-21",
+                token = token # Refer to login to obtain the API key
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        date = '2025-12-08'
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_warrant_trading_daily_report(
+            date=date,
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | securities_trader   |   price |   buy |   sell |   securities_trader_id |   stock_id | date       |
+        |---:|:--------------------|--------:|------:|-------:|-----------------------:|-----------:|:-----------|
+        |  0 | 元富                |    2.48 |     0 |   4000 |                   5920 |     084655 | 2023-06-21 |
+        |  1 | 凱基                |    2.48 |  4000 |      0 |                   9200 |     084655 | 2023-06-21 |
+    === "Schema"
+        ```
+        {
+            securities_trader: str, # securities trader name
+            price: float64, # transaction price
+            buy: int32, # shares bought
+            sell: int32, # shares sold
+            securities_trader_id: str, # securities trader code
+            stock_id: str, # stock symbol
+            date: str # date
+        }
+        ```
+
+----------------------------------
+#### Taiwan Stock Warrant Trading Daily Report by Branch (query by securities_trader_id) TaiwanStockWarrantTradingDailyReport (only available for [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2023-06-21 ~ now
+- Due to the large data volume, only one day of data is provided per request.
+- Data update time **Monday to Friday 23:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+
+        url = 'https://api.finmindtrade.com/api/v4/taiwan_stock_warrant_trading_daily_report'
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "securities_trader_id": "5920",
+            "date": "2023-06-21",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/taiwan_stock_warrant_trading_daily_report'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                securities_trader_id="5920",
+                start_date= "2023-06-21",
+                token = token # Refer to login to obtain the API key
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |     | securities_trader   |   price |    buy |   sell |   securities_trader_id | stock_id   | date       |
+        |----:|:--------------------|--------:|-------:|-------:|-----------------------:|:-----------|:-----------|
+        |   0 | 元富                |    0.97 |  50000 |      0 |                   5920 | 07741U     | 2023-06-21 |
+        |   1 | 元富                |    0.98 |  50000 |      0 |                   5920 | 07741U     | 2023-06-21 |
+        |   2 | 元富                |    1.52 | 100000 |      0 |                   5920 | 07742U     | 2023-06-21 |
+        |   3 | 元富                |    1.56 |  49000 |      0 |                   5920 | 07742U     | 2023-06-21 |
+    === "Schema"
+        ```
+        {
+            securities_trader: str, # securities trader name
+            price: float64, # transaction price
+            buy: int32, # shares bought
+            sell: int32, # shares sold
+            securities_trader_id: str, # securities trader code
+            stock_id: str, # stock symbol
+            date: str # date
+        }
+        ```
+
+----------------------------------
+#### Taiwan Stock Government Bank Buy/Sell TaiwanStockGovernmentBankBuySell (only available for [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2021-06-30 ~ now
+- Due to the large data volume, only one day of data is provided per request.
+- Data update time **Monday to Friday 23:30**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_government_bank_buy_sell(
+            start_date='2023-01-17',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockGovernmentBankBuySell",
+            "start_date": "2023-01-17",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockGovernmentBankBuySell",
+                start_date= "2023-01-17"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |     |       date       | stock_id |  buy_amount  |  sell_amount  |  buy   |  sell  |  bank_name |
+        |----:|:-----------------|---------:|-------------:|--------------:|-------:|-------:|-----------:|
+        |  0  |    2023-01-17    |   0050   |  43992298.6  |  53309904.25  |372595  |451744  |      兆豐  |
+        |  1  |    2023-01-17    |  5202    |       288.0  |       303.50  |    20  |    20  |      第一  |
+        |  2  |    2023-01-17    |  5202    |         0.0  |        59.45  |     0  |     4  |      華南  |
+        |  3  |    2023-01-17    |  5203    |     82800.0  |         0.00  |  1000  |     0  |      兆豐  |
+        |  4  |    2023-01-17    |  5203    |    249000.0  |    583600.00  |  3000  |  7000  |      臺銀  |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            buy_amount: float64, # buy amount
+            sell_amount: float64, # sell amount
+            buy: int64, # shares bought
+            sell: int64, # shares sold
+            bank_name: str # bank name
+        }
+        ```
+
+#### Taiwan Total Exchange Margin Maintenance TaiwanTotalExchangeMarginMaintenance (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2001-01-05 ~ now
+- Data update time **Monday to Friday 21:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_total_exchange_margin_maintenance(
+            start_date='2024-04-01',
+            end_date='2024-05-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanTotalExchangeMarginMaintenance",
+            "start_date": "2020-04-01",
+            "end_date": "2020-05-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanTotalExchangeMarginMaintenance",
+                start_date= "2024-04-01",
+                end_date='2024-05-01'
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   date | TotalExchangeMarginMaintenance       |
+        |---:|--------:|-------------------------------------:|
+        |  0  |    2024-04-01    |   166.007    |
+        |  1  |    2024-04-02    |   167.079    |
+        |  2  |    2024-04-03    |   167.085    |
+        |  3  |    2024-04-08    |   167.119    |
+        |  4  |    2024-04-09    |   167.095    |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            TotalExchangeMarginMaintenance: float64 # total exchange margin maintenance ratio
+        }
+        ```
+
+#### Daily Securities Trader Branch Aggregate Statistics TaiwanStockTradingDailyReportSecIdAgg (only available for [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Provides Taiwan stock trading by branch information for listed (TWSE), OTC, and emerging stocks!
+- Data range: 2021-06-30 ~ now
+- Data update time **Monday to Friday 21:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_trading_daily_report_secid_agg(
+            stock_id="2330",
+            securities_trader_id="1020",
+            start_date= "2024-07-01",
+            end_date="2024-07-15",
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/taiwan_stock_trading_daily_report_secid_agg"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "data_id": "2330",
+            "securities_trader_id": "1020",
+            "start_date": "2024-07-01",
+            "end_date": '2024-07-15',
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/taiwan_stock_trading_daily_report_secid_agg'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                data_id="2330",
+                securities_trader_id="1020",
+                start_date= "2024-07-01",
+                end_date='2024-07-15'
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | securities_trader | securities_trader_id |   stock_id |      date     |   buy_volume |  sell_volume | buy_price  | sell_price |
+        |---:|:------------------|---------------------:|-----------:|---------------:|------------:|-------------:|------------|:-----------|
+        |  0 | 合庫             |        1020          |     2330   |   2024-07-01  |    12157     |    12460     |    968.08   |   973.84    |
+        |  0 | 合庫             |        1020          |     2330   |   2024-07-02  |    12735     |    21885     |    964.54   |   964.63    |
+        |  0 | 合庫             |        1020          |     2330   |   2024-07-03  |    10535     |    29381     |    973.16   |   974.69    |
+        |  0 | 合庫             |        1020          |     2330   |   2024-07-04  |    28107     |    59459     |    1001.99  |   1000.88   |
+        |  0 | 合庫             |        1020          |     2330   |   2024-07-05  |    10435     |    11075     |    1004.18  |    1004.5   |
+    === "Schema"
+        ```
+        {
+            securities_trader: str, # securities trader name
+            securities_trader_id: str, # securities trader code
+            stock_id: str, # stock symbol
+            date: str, # date
+            buy_volume: int64, # total shares bought
+            sell_volume: int64, # total shares sold
+            buy_price: float, # average buy price
+            sell_price: float, # average sell price
+        }
+        ```
+
+#### Block Trading Daily Report TaiwanStockBlockTradingDailyReport (only available for [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2026-04-28 ~ now
+- Only requires a date input, no stock symbol needed.
+
+!!! example
+    === "Python"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        parameter = {
+            "dataset": "TaiwanStockBlockTradingDailyReport",
+            "start_date": "2026-04-28",
+            "token": token,
+        }
+        resp = requests.get(url, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        url = "https://api.finmindtrade.com/api/v4/data"
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockBlockTradingDailyReport",
+                start_date="2026-04-28",
+                token=""
+            )
+        )
+        data = content(response)
+        df = do.call('rbind', lapply(data$data, as.data.frame))
+        head(df)
+        ```
+
+!!! output
+    === "Schema"
+        ```
+        {
+            securities_trader: str, # securities trader
+            price: float, # price
+            buy: int, # shares bought
+            sell: int, # shares sold
+            trade_type: str, # trade type (paired/conversion, etc.)
+            securities_trader_id: str, # securities trader code
+            stock_id: str, # stock symbol
+            date: str, # date
+        }
+        ```
+
+#### Block Trade Daily Transactions TaiwanStockBlockTrade (only available for [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2005-04-04 ~ now
+- Covers block trades (tick-by-tick) for listed (TWSE) and OTC stocks.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_block_trade(
+            stock_id="2330",
+            start_date="2026-04-01",
+            end_date="2026-04-30",
+        )
+        ```
+    === "Python"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockBlockTrade",
+            "data_id": "2330",
+            "start_date": "2026-04-01",
+            "end_date": "2026-04-30",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockBlockTrade",
+                data_id="2330",
+                start_date="2026-04-01",
+                end_date="2026-04-30",
+                token=token
+            )
+        )
+        data = content(response)
+        df = do.call("rbind", lapply(data$data, as.data.frame))
+        head(df)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | trade_type   |   price |   volume |   trading_money |
+        |---:|:-----------|-----------:|:-------------|--------:|---------:|----------------:|
+        |  0 | 2026-04-01 |       2330 | 配對交易     | 1871.29 |    25000 |        46782250 |
+        |  1 | 2026-04-01 |       2330 | 配對交易     | 1871.28 |    25000 |        46782000 |
+        |  2 | 2026-04-01 |       2330 | 配對交易     | 1865.28 |    15000 |        27979200 |
+        |  3 | 2026-04-01 |       2330 | 配對交易     | 1855    |  1078000 |      1999690000 |
+        |  4 | 2026-04-01 |       2330 | 配對交易     | 1849.42 |   137104 |       253562880 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            trade_type: str, # trade type (paired trade, etc.)
+            price: float, # transaction price
+            volume: int, # transaction volume
+            trading_money: int, # trading money
+        }
+        ```
+
+#### Loan Collateral Balance TaiwanStockLoanCollateralBalance (only available for [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2006-10-02 ~ now
+- Data update time **Monday to Friday after market close**, the actual update time is based on the API data.
+- Includes the collateral balance (in thousand shares) for margin purchase, securities firm securities-business loans, securities firm unrestricted-purpose loans, securities finance secured loans, and securities finance settlement margin for listed (TWSE) and OTC stocks.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_loan_collateral_balance(
+            stock_id="2330",
+            start_date="2026-04-01",
+            end_date="2026-04-30",
+        )
+        ```
+    === "Python"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockLoanCollateralBalance",
+            "data_id": "2330",
+            "start_date": "2026-04-01",
+            "end_date": "2026-04-30",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockLoanCollateralBalance",
+                data_id="2330",
+                start_date="2026-04-01",
+                end_date="2026-04-30",
+                token=token
+            )
+        )
+        data = content(response)
+        df = do.call("rbind", lapply(data$data, as.data.frame))
+        head(df)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | market   |   MarginPreviousDayBalance |   MarginBuy |   MarginSell |   MarginCashRedemption |   MarginCurrentDayBalance |   MarginNextDayQuota |   SecuritiesFirmLoanPreviousDayBalance |   SecuritiesFirmLoanBuy |   SecuritiesFirmLoanSell |   SecuritiesFirmLoanCashRedemption |   SecuritiesFirmLoanReplacement |   SecuritiesFirmLoanCurrentDayBalance |   SecuritiesFirmLoanNextDayQuota |   UnrestrictedLoanPreviousDayBalance |   UnrestrictedLoanBuy |   UnrestrictedLoanSell |   UnrestrictedLoanCashRedemption |   UnrestrictedLoanReplacement |   UnrestrictedLoanCurrentDayBalance |   UnrestrictedLoanNextDayQuota |   SecuritiesFinanceSecuredLoanPreviousDayBalance |   SecuritiesFinanceSecuredLoanBuy |   SecuritiesFinanceSecuredLoanSell |   SecuritiesFinanceSecuredLoanCashRedemption |   SecuritiesFinanceSecuredLoanReplacement |   SecuritiesFinanceSecuredLoanCurrentDayBalance |   SecuritiesFinanceSecuredLoanNextDayQuota |   SettlementMarginPreviousDayBalance |   SettlementMarginBuy |   SettlementMarginSell |   SettlementMarginCashRedemption |   SettlementMarginReplacement |   SettlementMarginCurrentDayBalance |   SettlementMarginNextDayQuota |
+        |---:|:-----------|-----------:|:---------|---------------------------:|------------:|-------------:|-----------------------:|--------------------------:|---------------------:|---------------------------------------:|------------------------:|-------------------------:|-----------------------------------:|--------------------------------:|--------------------------------------:|---------------------------------:|-------------------------------------:|----------------------:|-----------------------:|---------------------------------:|------------------------------:|------------------------------------:|-------------------------------:|-------------------------------------------------:|----------------------------------:|-----------------------------------:|---------------------------------------------:|------------------------------------------:|------------------------------------------------:|-------------------------------------------:|-------------------------------------:|----------------------:|-----------------------:|---------------------------------:|------------------------------:|------------------------------------:|-------------------------------:|
+        |  0 | 2026-04-01 |       2330 | 集中市場 |                      26608 |        1268 |         1485 |                     38 |                     26353 |              6483131 |                                     21 |                       0 |                        0 |                                  0 |                               0 |                                    21 |                          1296626 |                               119953 |                   851 |                    142 |                               46 |                           215 |                              120401 |                        2593252 |                                            16700 |                               111 |                                 11 |                                           30 |                                         6 |                                           16764 |                                          0 |                                    0 |                     0 |                      0 |                                0 |                             0 |                                   0 |                        1296626 |
+        |  1 | 2026-04-02 |       2330 | 集中市場 |                      26353 |        1312 |          873 |                    194 |                     26598 |              6483131 |                                     21 |                       0 |                        0 |                                  0 |                               0 |                                    21 |                          1296626 |                               120401 |                   621 |                    139 |                               70 |                           416 |                              120397 |                        2593252 |                                            16764 |                               134 |                                  6 |                                           19 |                                        18 |                                           16855 |                                          0 |                                    0 |                     0 |                      0 |                                0 |                             0 |                                   0 |                        1296626 |
+        |  2 | 2026-04-07 |       2330 | 集中市場 |                      26598 |         391 |          970 |                     19 |                     26000 |              6483131 |                                     21 |                       0 |                        0 |                                  0 |                               0 |                                    21 |                          1296626 |                               120397 |                   539 |                     54 |                               36 |                           236 |                              120610 |                        2593252 |                                            16855 |                               160 |                                  2 |                                           67 |                                        29 |                                           16917 |                                          0 |                                    0 |                     0 |                      0 |                                0 |                             0 |                                   0 |                        1296626 |
+        |  3 | 2026-04-08 |       2330 | 集中市場 |                      26000 |        2882 |         2057 |                     28 |                     26797 |              6483131 |                                     21 |                      65 |                        0 |                                  0 |                               0 |                                    86 |                          1296626 |                               120616 |                   776 |                     75 |                              134 |                           222 |                              120961 |                        2593252 |                                            16917 |                                88 |                                 21 |                                           28 |                                         9 |                                           16947 |                                          0 |                                    0 |                     0 |                      0 |                                0 |                             0 |                                   0 |                        1296626 |
+        |  4 | 2026-04-09 |       2330 | 集中市場 |                      26604 |         998 |          953 |                     13 |                     26636 |              6483131 |                                     86 |                       0 |                       65 |                                  0 |                               0 |                                    21 |                          1296626 |                               120961 |                   481 |                     19 |                               83 |                           198 |                              121142 |                        2593252 |                                            16947 |                               126 |                                  1 |                                           27 |                                        13 |                                           17032 |                                          0 |                                    0 |                     0 |                      0 |                                0 |                             0 |                                   0 |                        1296626 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock symbol
+            market: str, # market type (TWSE/OTC)
+            MarginPreviousDayBalance: int, # margin purchase - previous day balance
+            MarginBuy: int, # margin purchase - buy
+            MarginSell: int, # margin purchase - sell
+            MarginCashRedemption: int, # margin purchase - cash redemption
+            MarginCurrentDayBalance: int, # margin purchase - current day balance
+            MarginNextDayQuota: int, # margin purchase - next business day quota
+            SecuritiesFirmLoanPreviousDayBalance: int, # securities firm securities-business loan - previous day balance
+            SecuritiesFirmLoanBuy: int, # securities firm securities-business loan - buy
+            SecuritiesFirmLoanSell: int, # securities firm securities-business loan - sell
+            SecuritiesFirmLoanCashRedemption: int, # securities firm securities-business loan - cash redemption
+            SecuritiesFirmLoanReplacement: int, # securities firm securities-business loan - replacement
+            SecuritiesFirmLoanCurrentDayBalance: int, # securities firm securities-business loan - current day balance
+            SecuritiesFirmLoanNextDayQuota: int, # securities firm securities-business loan - next business day quota
+            UnrestrictedLoanPreviousDayBalance: int, # securities firm unrestricted-purpose loan - previous day balance
+            UnrestrictedLoanBuy: int, # securities firm unrestricted-purpose loan - buy
+            UnrestrictedLoanSell: int, # securities firm unrestricted-purpose loan - sell
+            UnrestrictedLoanCashRedemption: int, # securities firm unrestricted-purpose loan - cash redemption
+            UnrestrictedLoanReplacement: int, # securities firm unrestricted-purpose loan - replacement
+            UnrestrictedLoanCurrentDayBalance: int, # securities firm unrestricted-purpose loan - current day balance
+            UnrestrictedLoanNextDayQuota: int, # securities firm unrestricted-purpose loan - next business day quota
+            SecuritiesFinanceSecuredLoanPreviousDayBalance: int, # securities finance secured loan - previous day balance
+            SecuritiesFinanceSecuredLoanBuy: int, # securities finance secured loan - buy
+            SecuritiesFinanceSecuredLoanSell: int, # securities finance secured loan - sell
+            SecuritiesFinanceSecuredLoanCashRedemption: int, # securities finance secured loan - cash redemption
+            SecuritiesFinanceSecuredLoanReplacement: int, # securities finance secured loan - replacement
+            SecuritiesFinanceSecuredLoanCurrentDayBalance: int, # securities finance secured loan - current day balance
+            SecuritiesFinanceSecuredLoanNextDayQuota: int, # securities finance secured loan - next business day quota
+            SettlementMarginPreviousDayBalance: int, # securities finance settlement margin - previous day balance
+            SettlementMarginBuy: int, # securities finance settlement margin - buy
+            SettlementMarginSell: int, # securities finance settlement margin - sell
+            SettlementMarginCashRedemption: int, # securities finance settlement margin - cash redemption
+            SettlementMarginReplacement: int, # securities finance settlement margin - replacement
+            SettlementMarginCurrentDayBalance: int, # securities finance settlement margin - current day balance
+            SettlementMarginNextDayQuota: int, # securities finance settlement margin - next business day quota
+        }
+        ```
+
+#### Disposition Securities Period TaiwanStockDispositionSecuritiesPeriod (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2001-01-01 ~ now
+- Data covers listed (TWSE), OTC, and emerging stocks.
+- Data update time **Monday to Saturday 20:00~23:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_disposition_securities_period(
+            stock_id="6477",
+            start_date='2025-01-01',
+            end_date='2025-02-01',
+        )
+        ```
+    === "Python"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDispositionSecuritiesPeriod",
+            "data_id": "6477",
+            "start_date": "2025-01-01",
+            "end_date": "2025-02-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockDispositionSecuritiesPeriod",
+                data_id= "6477",
+                start_date= "2025-01-01",
+                end_date= "2025-02-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   stock_name |   disposition_cnt |       condition     |   measure   |   period_start |   period_end |
+        |---:|:-----------|-----------:|-------------:|------------------:|--------------------:|-------------:|---------------|---------------|
+        |  0 | 2025-01-09 |       6477 |      安集    |         1         | 連續三次及當日沖銷標準 |   第一次處置 |    2025-01-10 |   2025-02-05 |
+    === "Schema"
+        ```
+        {
+            date: str, # announcement date
+            stock_id: str, # stock symbol
+            stock_name: str, # stock name
+            disposition_cnt: int32, # cumulative count
+            condition: str, # disposition condition
+            measure: str, # disposition measure
+            period_start: str, # disposition start date
+            period_end: str, # disposition end date
+        }
+        ```
+
+
+#### Get all data for a specific date in one request (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_disposition_securities_period(
+            start_date='2025-01-09',
+            end_date: "2025-01-09",
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDispositionSecuritiesPeriod",
+            "start_date": "2025-01-09",
+            "end_date": "2025-01-09",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockDispositionSecuritiesPeriod",
+                start_date= "2025-01-09",
+                end_date: "2025-01-09",
+                token = "" # Refer to login to obtain the API key
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   stock_name |   disposition_cnt |       condition     |   measure   |   period_start |   period_end |
+        |---:|:-----------|-----------:|-------------:|------------------:|--------------------:|-------------:|---------------|---------------|
+        |  0 | 2025-01-09 |       6477 |      安集    |         1         | 連續三次及當日沖銷標準 |   第一次處置 |    2025-01-10 |   2025-02-05 |
+        |  1 | 2025-01-09 |       9103 | 美德醫療-DR  |         1         | 最近十個營業日已有六次 |   第二次處置 |    2025-01-10 |   2025-02-03 |
+    === "Schema"
+        ```
+        {
+            date: str, # announcement date
+            stock_id: str, # stock symbol
+            stock_name: str, # stock name
+            disposition_cnt: int32, # cumulative count
+            condition: str, # disposition condition
+            measure: str, # disposition measure
+            period_start: str, # disposition start date
+            period_end: str, # disposition end date
+        }
+        ```
+
+----------------------------------
+
+#### Day Trading Borrowing Fee Rate TaiwanStockDayTradingBorrowingFeeRate (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2015-06-01 ~ now
+- Data update time **Monday to Friday 19:00~22:00**, the actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_day_trading_borrowing_fee_rate(
+            stock_id="2330",
+            start_date='2024-12-01',
+            end_date='2025-01-01',
+        )
+        ```
+    === "Python"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDayTradingBorrowingFeeRate",
+            "data_id": "2330",
+            "start_date": "2024-12-01",
+            "end_date": "2025-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockDayTradingBorrowingFeeRate",
+                data_id= "2330",
+                start_date= "2024-12-01",
+                end_date= "2025-01-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   stock_name | InvestorBorrowedShares |  InvestorBorrowingFeeRate  |
+        |---:|:-----------|-----------:|-------------:|-----------------------:|---------------------------:|
+        |  0 | 2024-12-02 |       6477 |      安集    |         15000           |              7             |
+    === "Schema"
+        ```
+        {
+            date: str, # announcement date
+            stock_id: str, # stock symbol
+            stock_name: str, # stock name
+            InvestorBorrowedShares: int32, # borrowed shares
+            InvestorBorrowingFeeRate: float64, # borrowing fee rate
+        }
+        ```
+
+
+#### Get all data for a specific date in one request (only available for [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_disposition_securities_period(
+            start_date='2024-12-02',
+            end_date: "2024-12-02",
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the API key
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDayTradingBorrowingFeeRate",
+            "start_date": "2024-12-02",
+            "end_date": "2024-12-02",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the API key
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockDayTradingBorrowingFeeRate",
+                start_date= "2024-12-02",
+                end_date: "2024-12-02",
+                token = "" # Refer to login to obtain the API key
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   stock_name     |   InvestorBorrowedShares |   InvestorBorrowingFeeRate   |
+        |---:|:-----------|-----------:|-----------------:|-------------------------:|-----------------------------:|
+        |  0 | 2024-12-02 |     00631L |   元大台灣50正2   |            5000          |              1               |
+        |  1 | 2024-12-02 |       1438 |      三地開發     |              1           |              3               |
+        |  2 | 2024-12-02 |       2312 |      金寶        |             1000          |              2               |
+        |  3 | 2024-12-02 |       2324 |      仁寶        |             1000          |            0.1               |
+        |  4 | 2024-12-02 |       2330 |      台積電      |            15000          |              7               |
+    === "Schema"
+        ```
+        {
+            date: str, # announcement date
+            stock_id: str, # stock symbol
+            stock_name: str, # stock name
+            InvestorBorrowedShares: int32, # borrowed shares
+            InvestorBorrowingFeeRate: float64, # borrowing fee rate
+        }
+        ```
+
+----------------------------------

--- a/docs/tutor/TaiwanMarket/ConvertibleBond.en.md
+++ b/docs/tutor/TaiwanMarket/ConvertibleBond.en.md
@@ -1,0 +1,594 @@
+
+For Taiwan stock convertible bonds, we have 4 datasets, as listed below:
+
+- [Convertible Bond Overview TaiwanStockConvertibleBondInfo](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebondinfo-backersponsor)
+- [Convertible Bond Daily Trading Information TaiwanStockConvertibleBondDaily](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebonddaily-backersponsor)
+- [Convertible Bond Institutional Investors Daily Trading TaiwanStockConvertibleBondInstitutionalInvestors](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebondinstitutionalinvestors-backersponsor)
+- [Convertible Bond Daily Overview TaiwanStockConvertibleBondDailyOverview](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebonddailyoverview-backersponsor)
+
+
+#### Convertible Bond Overview TaiwanStockConvertibleBondInfo (only available to [backer/sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_convertible_bond_info()
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockConvertibleBondInfo",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # See login section to obtain a token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockConvertibleBondInfo"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    |   cb_id | cb_name   | InitialDateOfConversion   | DueDateOfConversion   |   IssuanceAmount |
+        |---:|--------:|:----------|:--------------------------|:----------------------|-----------------:|
+        |  0 |   12101 | 大成一    | 2007-10-22                | 2012-09-11            |       1000000000 |
+        |  1 |   12161 | 統一一    | 2007-11-26                | 2010-10-15            |       5000000000 |
+        |  2 |   12171 | 愛之一    | 2011-06-12                | 2014-05-01            |       1100000000 |
+        |  3 |   12172 | 愛之二    | 2011-06-13                | 2016-05-02            |        300000000 |
+        |  4 |   12173 | 愛之味三  | 2013-04-08                | 2018-02-25            |       1000000000 |
+    === "Schema"
+        ```
+        {
+            cb_id: str, # convertible bond code
+            cb_name: str, # convertible bond name
+            InitialDateOfConversion: str, # initial date of conversion
+            DueDateOfConversion: str, # due date of conversion
+            IssuanceAmount: int # original issuance amount
+        }
+        ```
+
+---
+
+#### Convertible Bond Daily Trading Information TaiwanStockConvertibleBondDaily (only available to [backer/sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_convertible_bond_daily(
+            cb_id="15131",
+            start_date="2020-04-01",
+            end_date="2020-04-10",
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockConvertibleBondDaily",
+            "data_id":"15131",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-10",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+
+        token = "" # See login section to obtain a token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockConvertibleBondDaily",
+                data_id="15131",
+                start_date= "2020-04-01",
+                end_date='2020-04-10'
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    |   cb_id | cb_name   | transaction_type   |   close |   change |   open |   max |   min |   no_of_transactions |   unit |   trading_value |   avg_price |   next_ref_price |   next_max_limit |   next_min_limit | date       |
+        |---:|--------:|:----------|:-------------------|--------:|---------:|-------:|------:|------:|---------------------:|-------:|----------------:|------------:|-----------------:|-----------------:|-----------------:|:-----------|
+        |  0 |   15131 | 中興電一  | 等價               |   104   |     -0.5 | 103.6  | 104   | 103.5 |                   14 |    116 |        12029500 |      103.7  |            104   |           114.4  |            93.6  | 2020-04-01 |
+        |  1 |   15131 | 中興電一  | 等價               |   104.4 |      0.4 | 104    | 104.4 | 103.8 |                    9 |     29 |         3016200 |      104    |            104.4 |           114.8  |            94    | 2020-04-06 |
+        |  2 |   15131 | 中興電一  | 等價               |   105.8 |      1.4 | 105.15 | 105.8 | 104.5 |                   21 |    113 |        11877450 |      105.11 |            105.8 |           116.35 |            95.25 | 2020-04-07 |
+        |  3 |   15131 | 中興電一  | 等價               |   105.6 |     -0.2 | 105    | 106   | 105   |                   12 |     32 |         3370500 |      105.32 |            105.6 |           116.15 |            95.05 | 2020-04-08 |
+        |  4 |   15131 | 中興電一  | 等價               |   104.8 |     -0.8 | 104    | 105   | 104   |                   12 |     40 |         4177800 |      104.44 |            104.8 |           115.25 |            94.35 | 2020-04-09 |
+    === "Schema"
+        ```
+        {
+            cb_id: str, # convertible bond code
+            cb_name: str, # convertible bond name
+            transaction_type: str, # transaction status
+            close: float32, # closing price
+            change: float32, # price change
+            open: float32, # opening price
+            max: float32, # high
+            min: float32, # low
+            no_of_transactions: int64, # number of transactions
+            unit: int64, # volume
+            trading_value: int64, # transaction value
+            avg_price: float32, # average transaction price
+            next_ref_price: float32, # next-day reference price
+            next_max_limit: float32, # next-day price limit up
+            next_min_limit: float32, # next-day price limit down
+            date: str # date
+        }
+        ```
+
+#### Fetch all data for a specific date in one request (only available to [backer/sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_convertible_bond_daily(
+            start_date="2020-04-06",
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockConvertibleBondDaily",
+            "start_date": "2020-04-06",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # See login section to obtain a token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockConvertibleBondDaily",
+                start_date= "2020-04-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   cb_id | cb_name   | transaction_type   |   close |   change |   open |   max |   min |   no_of_transactions |   unit |   trading_value |   avg_price |   next_ref_price |   next_max_limit |   next_min_limit | date       |
+        |---:|--------:|:----------|:-------------------|--------:|---------:|-------:|------:|------:|---------------------:|-------:|----------------:|------------:|-----------------:|-----------------:|-----------------:|:-----------|
+        |  0 |   12582 | 其祥二KY  | 等價               |       0 |        0 |      0 |     0 |     0 |                    0 |      0 |               0 |       87.43 |            87.2  |            95.9  |            78.5  | 2020-04-06 |
+        |  1 |   13163 | 上曜三    | 等價               |       0 |        0 |      0 |     0 |     0 |                    0 |      0 |               0 |      101.68 |           102    |           112.2  |            91.8  | 2020-04-06 |
+        |  2 |   14361 | 華友聯一  | 等價               |     107 |        0 |    107 |   107 |   107 |                    1 |      2 |          214000 |      107    |           107    |           117.7  |            96.3  | 2020-04-06 |
+        |  3 |   14423 | 名軒三    | 等價               |       0 |        0 |      0 |     0 |     0 |                    0 |      0 |               0 |      135    |           135    |           148.5  |           121.5  | 2020-04-06 |
+        |  4 |   14721 | 三洋紡一  | 等價               |       0 |        0 |      0 |     0 |     0 |                    0 |      0 |               0 |      100.35 |           100.35 |           110.35 |            90.35 | 2020-04-06 |
+    === "Schema"
+        ```
+        {
+            cb_id: str, # convertible bond code
+            cb_name: str, # convertible bond name
+            transaction_type: str, # transaction status
+            close: float32, # closing price
+            change: float32, # price change
+            open: float32, # opening price
+            max: float32, # high
+            min: float32, # low
+            no_of_transactions: int64, # number of transactions
+            unit: int64, # volume
+            trading_value: int64, # transaction value
+            avg_price: float32, # average transaction price
+            next_ref_price: float32, # next-day reference price
+            next_max_limit: float32, # next-day price limit up
+            next_min_limit: float32, # next-day price limit down
+            date: str # date
+        }
+        ```
+
+---
+
+#### Convertible Bond Institutional Investors Daily Trading TaiwanStockConvertibleBondInstitutionalInvestors (only available to [backer/sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_convertible_bond_institutional_investors(
+            cb_id="15131",
+            start_date="2020-04-01",
+            end_date="2020-04-10",
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockConvertibleBondInstitutionalInvestors",
+            "data_id":"15131",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-10",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # See login section to obtain a token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockConvertibleBondInstitutionalInvestors",
+                data_id="15131",
+                start_date= "2020-04-01",
+                end_date='2020-04-10'
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    |   Foreign_Investor_Buy |   Foreign_Investor_Sell |   Foreign_Investor_Overbuy |   Investment_Trust_Buy |   Investment_Trust_Sell |   Investment_Trust_Overbuy |   Dealer_self_Buy |   Dealer_self_Sell |   Dealer_self_Overbuy |   Total_Overbuy |   cb_id | cb_name    | date       |
+        |---:|-----------------------:|------------------------:|---------------------------:|-----------------------:|------------------------:|---------------------------:|------------------:|-------------------:|----------------------:|----------------:|--------:|:-----------|:-----------|
+        |  0 |                      0 |                       0 |                          0 |                      0 |                       0 |                          0 |                 2 |                  2 |                     0 |               0 |   14361 | 華友聯一   | 2020-04-06 |
+        |  1 |                      0 |                       0 |                          0 |                      0 |                       0 |                          0 |                12 |                 28 |                   -16 |             -16 |   15131 | 中興電一   | 2020-04-06 |
+        |  2 |                      0 |                       0 |                          0 |                      0 |                       0 |                          0 |                 5 |                  0 |                     5 |               5 |   15981 | 岱宇一     | 2020-04-06 |
+        |  3 |                      0 |                      10 |                        -10 |                      0 |                       0 |                          0 |                13 |                  0 |                    13 |               3 |   16262 | 艾美特二KY | 2020-04-06 |
+        |  4 |                      0 |                       0 |                          0 |                      0 |                       0 |                          0 |                20 |                 20 |                     0 |               0 |   17333 | 五鼎三     | 2020-04-06 |
+    === "Schema"
+        ```
+        {
+            Foreign_Investor_Buy: int64, # foreign investor buy volume
+            Foreign_Investor_Sell: int64, # foreign investor sell volume
+            Foreign_Investor_Overbuy: int64, # foreign investor net buy volume
+            Investment_Trust_Buy: int64, # investment trust buy volume
+            Investment_Trust_Sell: int64, # investment trust sell volume
+            Investment_Trust_Overbuy: int64, # investment trust net buy volume
+            Dealer_self_Buy: int64, # dealer buy volume
+            Dealer_self_Sell: int64, # dealer sell volume
+            Dealer_self_Overbuy: int64, # dealer net buy volume
+            Total_Overbuy: int64, # total net buy volume
+            cb_id: str, # convertible bond code
+            cb_name: str, # convertible bond name
+            date: str # date
+        }
+        ```
+
+#### Fetch all data for a specific date in one request (only available to [backer/sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_convertible_bond_institutional_investors(
+            start_date="2020-04-06",
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockConvertibleBondInstitutionalInvestors",
+            "start_date": "2020-04-06",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # See login section to obtain a token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockConvertibleBondInstitutionalInvestors",
+                start_date= "2020-04-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   Foreign_Investor_Buy |   Foreign_Investor_Sell |   Foreign_Investor_Overbuy |   Investment_Trust_Buy |   Investment_Trust_Sell |   Investment_Trust_Overbuy |   Dealer_self_Buy |   Dealer_self_Sell |   Dealer_self_Overbuy |   Total_Overbuy |   cb_id | cb_name    | date       |
+        |---:|-----------------------:|------------------------:|---------------------------:|-----------------------:|------------------------:|---------------------------:|------------------:|-------------------:|----------------------:|----------------:|--------:|:-----------|:-----------|
+        |  0 |                      0 |                       0 |                          0 |                      0 |                       0 |                          0 |                 2 |                  2 |                     0 |               0 |   14361 | 華友聯一   | 2020-04-06 |
+        |  1 |                      0 |                       0 |                          0 |                      0 |                       0 |                          0 |                12 |                 28 |                   -16 |             -16 |   15131 | 中興電一   | 2020-04-06 |
+        |  2 |                      0 |                       0 |                          0 |                      0 |                       0 |                          0 |                 5 |                  0 |                     5 |               5 |   15981 | 岱宇一     | 2020-04-06 |
+        |  3 |                      0 |                      10 |                        -10 |                      0 |                       0 |                          0 |                13 |                  0 |                    13 |               3 |   16262 | 艾美特二KY | 2020-04-06 |
+        |  4 |                      0 |                       0 |                          0 |                      0 |                       0 |                          0 |                20 |                 20 |                     0 |               0 |   17333 | 五鼎三     | 2020-04-06 |
+    === "Schema"
+        ```
+        {
+            Foreign_Investor_Buy: int64, # foreign investor buy volume
+            Foreign_Investor_Sell: int64, # foreign investor sell volume
+            Foreign_Investor_Overbuy: int64, # foreign investor net buy volume
+            Investment_Trust_Buy: int64, # investment trust buy volume
+            Investment_Trust_Sell: int64, # investment trust sell volume
+            Investment_Trust_Overbuy: int64, # investment trust net buy volume
+            Dealer_self_Buy: int64, # dealer buy volume
+            Dealer_self_Sell: int64, # dealer sell volume
+            Dealer_self_Overbuy: int64, # dealer net buy volume
+            Total_Overbuy: int64, # total net buy volume
+            cb_id: str, # convertible bond code
+            cb_name: str, # convertible bond name
+            date: str # date
+        }
+        ```
+
+---
+
+#### Convertible Bond Daily Overview TaiwanStockConvertibleBondDailyOverview (only available to [backer/sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_convertible_bond_daily_overview(
+            cb_id="15131",
+            start_date="2020-04-01",
+            end_date="2020-04-10",
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockConvertibleBondDailyOverview",
+            "data_id":"15131",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-10",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # See login section to obtain a token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockConvertibleBondDailyOverview",
+                data_id="15131",
+                start_date= "2020-04-01",
+                end_date='2020-04-10'
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    |   cb_id | cb_name   | date       | InitialDateOfConversion   | DueDateOfConversion   | InitialDateOfStopConversion   | DueDateOfStopConversion   |   ConversionPrice | NextEffectiveDateOfConversionPrice   | LatestInitialDateOfPut   | LatestDueDateOfPut   |   LatestPutPrice | InitialDateOfEarlyRedemption   | DueDateOfEarlyRedemption   |   EarlyRedemptionPrice | DateOfDelisted   |   IssuanceAmount |   OutstandingAmount |   ReferencePrice |   PriceOfUnderlyingStock | InitialDateOfSuspension   | DueDateOfSuspension   |   CouponRate |
+        |---:|--------:|:----------|:-----------|:--------------------------|:----------------------|:------------------------------|:--------------------------|------------------:|:-------------------------------------|:-------------------------|:---------------------|-----------------:|:-------------------------------|:---------------------------|-----------------------:|:-----------------|-----------------:|--------------------:|-----------------:|-------------------------:|:--------------------------|:----------------------|-------------:|
+        |  0 |   15131 | 中興電一  | 2020-04-01 | 2020-04-17                | 2025-01-16            |                               |                           |              27.7 | 2020-01-16                           |                          |                      |                0 |                                |                            |                      0 |                  |          1.5e+09 |             1.5e+09 |            104   |                    22.2  |                           |                       |            0 |
+        |  1 |   15131 | 中興電一  | 2020-04-06 | 2020-04-17                | 2025-01-16            |                               |                           |              27.7 | 2020-01-16                           |                          |                      |                0 |                                |                            |                      0 |                  |          1.5e+09 |             1.5e+09 |            104.4 |                    22.25 |                           |                       |            0 |
+        |  2 |   15131 | 中興電一  | 2020-04-07 | 2020-04-17                | 2025-01-16            |                               |                           |              27.7 | 2020-01-16                           |                          |                      |                0 |                                |                            |                      0 |                  |          1.5e+09 |             1.5e+09 |            105.8 |                    23.15 |                           |                       |            0 |
+        |  3 |   15131 | 中興電一  | 2020-04-08 | 2020-04-17                | 2025-01-16            |                               |                           |              27.7 | 2020-01-16                           |                          |                      |                0 |                                |                            |                      0 |                  |          1.5e+09 |             1.5e+09 |            105.6 |                    23.35 |                           |                       |            0 |
+        |  4 |   15131 | 中興電一  | 2020-04-09 | 2020-04-17                | 2025-01-16            |                               |                           |              27.7 | 2020-01-16                           |                          |                      |                0 |                                |                            |                      0 |                  |          1.5e+09 |             1.5e+09 |            104.8 |                    23.25 |                           |                       |            0 |
+    === "Schema"
+        ```
+        {
+            cb_id: str, # convertible bond code
+            cb_name: str, # convertible bond name
+            date: str, # date
+            InitialDateOfConversion: str, # initial date of conversion
+            DueDateOfConversion: str, # due date of conversion
+            InitialDateOfStopConversion: str, # latest initial date of suspension of conversion
+            DueDateOfStopConversion: str, # latest due date of suspension of conversion
+            ConversionPrice: float32, # conversion price
+            NextEffectiveDateOfConversionPrice: str, # next effective date of conversion price
+            LatestInitialDateOfPut: str, # latest initial put date
+            LatestDueDateOfPut: str, # latest due put date
+            LatestPutPrice: float32, # latest put price
+            InitialDateOfEarlyRedemption: str, # initial date of early redemption
+            DueDateOfEarlyRedemption: str, # due date of early redemption
+            EarlyRedemptionPrice: float32, # early redemption price
+            DateOfDelisted: str, # date of delisting from OTC trading
+            IssuanceAmount: float32, # original issuance amount
+            OutstandingAmount: float32, # outstanding balance at end of last month
+            ReferencePrice: float32, # convertible bond reference price
+            PriceOfUnderlyingStock: float32, # price of underlying stock
+            InitialDateOfSuspension: str, # initial date of trading suspension
+            DueDateOfSuspension: str, # due date of trading suspension
+            CouponRate: float32 # coupon rate
+        }
+        ```
+
+#### Fetch all data for a specific date in one request (only available to [backer/sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_convertible_bond_daily_overview(
+            start_date="2020-04-06",
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockConvertibleBondDailyOverview",
+            "start_date": "2020-04-06",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # See login section to obtain a token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockConvertibleBondDailyOverview",
+                start_date= "2020-04-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   cb_id | cb_name   | date       | InitialDateOfConversion   | DueDateOfConversion   | InitialDateOfStopConversion   | DueDateOfStopConversion   |   ConversionPrice | NextEffectiveDateOfConversionPrice   | LatestInitialDateOfPut   | LatestDueDateOfPut   |   LatestPutPrice | InitialDateOfEarlyRedemption   | DueDateOfEarlyRedemption   |   EarlyRedemptionPrice | DateOfDelisted   |   IssuanceAmount |   OutstandingAmount |   ReferencePrice |   PriceOfUnderlyingStock | InitialDateOfSuspension   | DueDateOfSuspension   |   CouponRate |
+        |---:|--------:|:----------|:-----------|:--------------------------|:----------------------|:------------------------------|:--------------------------|------------------:|:-------------------------------------|:-------------------------|:---------------------|-----------------:|:-------------------------------|:---------------------------|-----------------------:|:-----------------|-----------------:|--------------------:|-----------------:|-------------------------:|:--------------------------|:----------------------|-------------:|
+        |  0 |   12582 | 其祥二KY  | 2020-04-06 | 2019-01-11                | 2023-09-10            |                               |                           |              30   | 2018-09-10                           |                          |                      |             0    |                                |                            |                      0 |                  |            3e+08 |           2.999e+08 |            87.2  |                     9.34 |                           |                       |            0 |
+        |  1 |   13163 | 上曜三    | 2020-04-06 | 2019-02-08                | 2021-11-07            |                               |                           |              14.7 | 2019-08-07                           |                          |                      |             0    |                                |                            |                      0 |                  |            5e+08 |           4.556e+08 |           102    |                     8.34 |                           |                       |            0 |
+        |  2 |   14361 | 華友聯一  | 2020-04-06 | 2020-04-18                | 2025-01-17            |                               |                           |              40   | 2020-01-17                           |                          |                      |             0    |                                |                            |                      0 |                  |            3e+08 |           3e+08     |           107    |                    36    |                           |                       |            0 |
+        |  3 |   14423 | 名軒三    | 2020-04-06 | 2016-01-02                | 2020-12-01            |                               |                           |              11.5 | 2019-08-17                           | 2018-10-23               | 2018-12-01           |           103.79 |                                |                            |                      0 |                  |            8e+08 |           6.4e+08   |           135    |                    14.9  |                           |                       |            0 |
+        |  4 |   14721 | 三洋紡一  | 2020-04-06 | 2019-05-01                | 2022-01-30            |                               |                           |              29.2 | 2019-03-19                           |                          |                      |             0    |                                |                            |                      0 |                  |            3e+08 |           2.889e+08 |           100.35 |                     9.2  |                           |                       |            0 |
+    === "Schema"
+        ```
+        {
+            cb_id: str, # convertible bond code
+            cb_name: str, # convertible bond name
+            date: str, # date
+            InitialDateOfConversion: str, # initial date of conversion
+            DueDateOfConversion: str, # due date of conversion
+            InitialDateOfStopConversion: str, # latest initial date of suspension of conversion
+            DueDateOfStopConversion: str, # latest due date of suspension of conversion
+            ConversionPrice: float32, # conversion price
+            NextEffectiveDateOfConversionPrice: str, # next effective date of conversion price
+            LatestInitialDateOfPut: str, # latest initial put date
+            LatestDueDateOfPut: str, # latest due put date
+            LatestPutPrice: float32, # latest put price
+            InitialDateOfEarlyRedemption: str, # initial date of early redemption
+            DueDateOfEarlyRedemption: str, # due date of early redemption
+            EarlyRedemptionPrice: float32, # early redemption price
+            DateOfDelisted: str, # date of delisting from OTC trading
+            IssuanceAmount: float32, # original issuance amount
+            OutstandingAmount: float32, # outstanding balance at end of last month
+            ReferencePrice: float32, # convertible bond reference price
+            PriceOfUnderlyingStock: float32, # price of underlying stock
+            InitialDateOfSuspension: str, # initial date of trading suspension
+            DueDateOfSuspension: str, # due date of trading suspension
+            CouponRate: float32 # coupon rate
+        }
+        ```

--- a/docs/tutor/TaiwanMarket/DataList.en.md
+++ b/docs/tutor/TaiwanMarket/DataList.en.md
@@ -1,0 +1,106 @@
+In the Taiwan financial market, we have 79 datasets, as listed below:
+
+#### Technical
+
+- [Taiwan Stock Overview TaiwanStockInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfo)
+- [Taiwan Stock Overview (with Warrants) TaiwanStockInfoWithWarrant](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrant)
+- [Taiwan Warrant Underlying Reference Table TaiwanStockInfoWithWarrantSummary](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrantsummary-sponsor)
+- [Taiwan Stock Trading Dates TaiwanStockTradingDate](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstocktradingdate)
+- [Taiwan Stock Price Table TaiwanStockPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockprice)
+- [Taiwan Adjusted Stock Price Table TaiwanStockPriceAdj](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockpriceadj-backersponsor)
+- [Taiwan Historical Tick-Level Stock Price Table TaiwanStockPriceTick](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockpricetick-backersponsor)
+- [Per-Stock PER, PBR Table TaiwanStockPER](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#perpbr-taiwanstockper)
+- [Order Book and Trade Statistics Every 5 Seconds TaiwanStockStatisticsOfOrderBookAndTrade](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#5-taiwanstockstatisticsoforderbookandtrade)
+- [Taiwan Weighted Index TaiwanVariousIndicators5Seconds](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanvariousindicators5seconds)
+- [Day-Trading Securities and Trading Volume/Value TaiwanStockDayTrading](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockdaytrading)
+- [Weighted/OTC Total Return Indices TaiwanStockTotalReturnIndex](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstocktotalreturnindex)
+- [Taiwan Per-Stock 10-Year Data Table TaiwanStock10Year](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstock10year-backersponsor)
+- [Taiwan Stock Minute K-Bar Table TaiwanStockKBar](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#k-taiwanstockkbar-sponsor)
+- [Taiwan Stock Weekly K-Bar Table TaiwanStockWeekPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#k-taiwanstockweekprice-backersponsor)
+- [Taiwan Stock Monthly K-Bar Table TaiwanStockMonthPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#k-taiwanstockmonthprice-backersponsor)
+- [Index Statistics Every 5 Seconds TaiwanStockEvery5SecondsIndex](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#5-taiwanstockevery5secondsindex-backersponsor)
+- [Taiwan Stock Trading Suspension Announcements TaiwanStockSuspended](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstocksuspended-backersponsor)
+- [Suspended Sell-First-Then-Buy Day-Trading Pre-Announcement TaiwanStockDayTradingSuspension](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockdaytradingsuspension-backersponsor)
+- [Daily Price Limit Up/Down TaiwanStockPriceLimit](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockpricelimit-backersponsor)
+
+#### Chip
+
+- [Per-Stock Margin Purchase / Short Sale Table TaiwanStockMarginPurchaseShortSale](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockmarginpurchaseshortsale)
+- [Total Market Margin Purchase / Short Sale Table TaiwanStockTotalMarginPurchaseShortSale](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocktotalmarginpurchaseshortsale)
+- [Per-Stock Institutional Investors Buy/Sell Table TaiwanStockInstitutionalInvestorsBuySell](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockinstitutionalinvestorsbuysell)
+- [Total Market Institutional Investors Buy/Sell Table TaiwanStockTotalInstitutionalInvestors](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocktotalinstitutionalinvestors)
+- [Foreign Investors Shareholding Table TaiwanStockShareholding](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockshareholding)
+- [Shareholding by Tier Table TaiwanStockHoldingSharesPer](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockholdingsharesper-backersponsor)
+- [Securities Lending Trade Details TaiwanStockSecuritiesLending](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocksecuritieslending)
+- [Suspended Short-Sale (Cover Date) Table TaiwanStockMarginShortSaleSuspension](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockmarginshortsalesuspension)
+- [Credit Quota Total Balance Table TaiwanDailyShortSaleBalances](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwandailyshortsalebalances)
+- [Securities Trader Information Table TaiwanSecuritiesTraderInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#TaiwanSecuritiesTraderInfo)
+- [Taiwan Stock Branch-Level Trading Table (query by stock code) TaiwanStockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#query-by-taiwanstocktradingdailyreport-sponsor)
+- [Taiwan Stock Branch-Level Trading Table (query by broker code) TaiwanStockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#query-by-taiwanstocktradingdailyreport-sponsor_1)
+- [Taiwan Warrant Branch-Level Trading Table (query by stock code) TaiwanStockWarrantTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#query-by-taiwanstockwarranttradingdailyreport-sponsor)
+- [Taiwan Warrant Branch-Level Trading Table (query by broker code) TaiwanStockWarrantTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#query-by-taiwanstockwarranttradingdailyreport-sponsor_1)
+- [Taiwan Top 8 Government Banks Buy/Sell Table TaiwanstockGovernmentBankBuySell](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockgovernmentbankbuysell-sponsor)
+- [Taiwan Total Exchange Margin Maintenance Ratio TaiwanTotalExchangeMarginMaintenance](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwantotalexchangemarginmaintenance-backersponsor)
+- [Daily Broker Branch Aggregate Statistics TaiwanStockTradingDailyReportSecIdAgg](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstocktradingdailyreportsecidagg-sponsor)
+- [Block Trade Daily Report TaiwanStockBlockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockblocktradingdailyreport-sponsor)
+- [Block Trade Daily Trading Information TaiwanStockBlockTrade](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockblocktrade-sponsor)
+- [Loan Collateral Balance Table TaiwanStockLoanCollateralBalance](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockloancollateralbalance-sponsor)
+- [Disposition Securities Announcement Table TaiwanStockDispositionSecuritiesPeriod](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdispositionsecuritiesperiod-backersponsor)
+- [Cash Day-Trading Short-Borrow Fee Rate TaiwanStockDayTradingBorrowingFeeRate](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdaytradingborrowingfeerate-backersponsor)
+
+#### Fundamental
+
+- [Cash Flow Statement TaiwanStockCashFlowsStatement](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockcashflowsstatement)
+- [Comprehensive Income Statement TaiwanStockFinancialStatements](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockfinancialstatements)
+- [Balance Sheet TaiwanStockBalanceSheet](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockbalancesheet)
+- [Dividend Policy Table TaiwanStockDividend](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockdividend)
+- [Ex-Dividend / Ex-Rights Result Table TaiwanStockDividendResult](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockdividendresult)
+- [Monthly Revenue Table TaiwanStockMonthRevenue](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockmonthrevenue)
+- [Capital Reduction Resumption Reference Price TaiwanStockCapitalReductionReferencePrice](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockcapitalreductionreferenceprice)
+- [Taiwan Stock Market Capitalization Table TaiwanStockMarketValue](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockmarketvalue-backersponsor)
+- [Taiwan Stock Delisting Table TaiwanStockDelisting](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockdelisting)
+- [Taiwan Stock Market Cap Weighting Table TaiwanStockMarketValueWeight](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockmarketvalueweight-backersponsor)
+- [Taiwan Stock Post-Split Reference Price TaiwanStockSplitPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstocksplitprice)
+- [Taiwan Stock Par Value Change Resumption Reference Price TaiwanStockParValueChange](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockparvaluechange)
+
+#### Derivative
+
+- [Futures and Options Daily Trading Information Overview TaiwanFutOptDailyInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfutoptdailyinfo)
+- [Futures Daily Trading Information TaiwanFuturesDaily](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesdaily)
+- [Options Daily Trading Information TaiwanOptionDaily](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptiondaily)
+- [Futures Trade Detail Table TaiwanFuturesTick](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturestick-backersponsor)
+- [Options Trade Detail Table TaiwanOptionTIck](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptiontick-backersponsor)
+- [Futures Institutional Investors Buy/Sell TaiwanFuturesInstitutionalInvestors](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesinstitutionalinvestors)
+- [Options Institutional Investors Buy/Sell TaiwanOptionInstitutionalInvestors](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptioninstitutionalinvestors)
+- [Futures After-Hours Institutional Investors Buy/Sell TaiwanFuturesInstitutionalInvestorsAfterHours](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesinstitutionalinvestorsafterhours-backersponsor)
+- [Options After-Hours Institutional Investors Buy/Sell TaiwanOptionInstitutionalInvestorsAfterHours](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptioninstitutionalinvestorsafterhours-backersponsor)
+- [Futures Per-Broker Daily Trading TaiwanFuturesDealerTradingVolumeDaily](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesdealertradingvolumedaily)
+- [Options Per-Broker Daily Trading TaiwanOptionDealerTradingVolumeDaily](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptiondealertradingvolumedaily)
+- [Futures Open Interest of Large Traders TaiwanFuturesOpenInterestLargeTraders](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesopeninterestlargetraders-backersponsor)
+- [Options Open Interest of Large Traders TaiwanOptionOpenInterestLargeTraders](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptionopeninterestlargetraders-backersponsor)
+- [Futures Spread Trading Quotes TaiwanFuturesSpreadTrading](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesspreadtrading-backersponsor)
+- [Futures Final Settlement Price TaiwanFuturesFinalSettlementPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesfinalsettlementprice-backersponsor)
+- [Options Final Settlement Price TaiwanOptionFinalSettlementPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptionfinalsettlementprice-backersponsor)
+
+#### RealTime
+
+- [Taiwan Stock Real-Time Information taiwan_stock_tick_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan_stock_tick_snapshot-sponsor)
+- [Futures and Options Real-Time Quote Overview TaiwanFutOptTickInfo](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwanfutopttickinfo)
+- [Taiwan Futures Real-Time Information taiwan_futures_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan_futures_snapshot-sponsor)
+- [Taiwan Options Real-Time Information taiwan_options_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan_options_snapshot-sponsor)
+
+#### ConvertibleBond
+
+- [Convertible Bond Overview TaiwanStockConvertibleBondInfo](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebondinfo-backersponsor)
+- [Convertible Bond Daily Trading Information TaiwanStockConvertibleBondDaily](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebonddaily-backersponsor)
+- [Convertible Bond Institutional Investors Daily Trading TaiwanStockConvertibleBondInstitutionalInvestors](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebondinstitutionalinvestors-backersponsor)
+- [Convertible Bond Daily Overview TaiwanStockConvertibleBondDailyOverview](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebonddailyoverview-backersponsor)
+
+
+#### Others
+
+- [Related News TaiwanStockNews](https://finmind.github.io/en/tutor/TaiwanMarket/Others/#taiwanstocknews)
+- [Taiwan Monthly Business Indicator Table TaiwanBusinessIndicator](https://finmind.github.io/en/tutor/TaiwanMarket/Others/#taiwanbusinessindicator-backersponsor)
+- [Per-Company Industry Chain TaiwanStockIndustryChain](https://finmind.github.io/en/tutor/TaiwanMarket/Others/#taiwanstockindustrychain-backersponsor)
+
+For detailed schemas, please refer to [finmind](https://finmindtrade.com/analysis/#/data/document)

--- a/docs/tutor/TaiwanMarket/Derivative.en.md
+++ b/docs/tutor/TaiwanMarket/Derivative.en.md
@@ -1,0 +1,2347 @@
+
+In Taiwan stock derivatives data, we have 16 datasets, as follows:
+
+- [Futures and Options Daily Trading Information Overview TaiwanFutOptDailyInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfutoptdailyinfo)
+- [Futures Daily Trading Information TaiwanFuturesDaily](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesdaily)
+- [Options Daily Trading Information TaiwanOptionDaily](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptiondaily)
+- [Futures Trading Detail Table TaiwanFuturesTick](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturestick-backersponsor)
+- [Options Trading Detail Table TaiwanOptionTick](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptiontick-backersponsor)
+- [Futures Top Three Institutional Investors Trading TaiwanFuturesInstitutionalInvestors](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesinstitutionalinvestors)
+- [Options Top Three Institutional Investors Trading TaiwanOptionInstitutionalInvestors](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptioninstitutionalinvestors)
+- [Futures After-Hours Top Three Institutional Investors Trading TaiwanFuturesInstitutionalInvestorsAfterHours](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesinstitutionalinvestorsafterhours-backersponsor)
+- [Options After-Hours Top Three Institutional Investors Trading TaiwanOptionInstitutionalInvestorsAfterHours](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptioninstitutionalinvestorsafterhours-backersponsor)
+- [Futures Daily Trading Volume by Dealer TaiwanFuturesDealerTradingVolumeDaily](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesdealertradingvolumedaily)
+- [Options Daily Trading Volume by Dealer TaiwanOptionDealerTradingVolumeDaily](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptiondealertradingvolumedaily)
+- [Futures Open Interest of Large Traders TaiwanFuturesOpenInterestLargeTraders](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesopeninterestlargetraders-backersponsor)
+- [Options Open Interest of Large Traders TaiwanOptionOpenInterestLargeTraders](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptionopeninterestlargetraders-backersponsor)
+- [Futures Final Settlement Price TaiwanFuturesFinalSettlementPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesfinalsettlementprice-backersponsor)
+- [Options Final Settlement Price TaiwanOptionFinalSettlementPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptionfinalsettlementprice-backersponsor)
+
+----------------------------------
+#### Futures and Options Daily Trading Information Overview TaiwanFutOptDailyInfo
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futopt_daily_info()
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFutOptDailyInfo",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFutOptDailyInfo"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    | code   | type              | name             |
+        |---:|:-------|:------------------|:-----------------|
+        |  0 | AAA    | TaiwanOptionDaily | 南亞1000股選擇權 |
+        |  1 | AAO    | TaiwanOptionDaily | 南亞選擇權       |
+        |  2 | ABA    | TaiwanOptionDaily | 中鋼1000股選擇權 |
+        |  3 | ABO    | TaiwanOptionDaily | 中鋼選擇權       |
+        |  4 | ACA    | TaiwanOptionDaily | 聯電選擇權       |
+    === "Schema"
+        ```
+        {
+            code: str, # product code
+            type: str, # type
+            name: str # product name
+        }
+        ```
+
+----------------------------------
+#### Futures Daily Trading Information TaiwanFuturesDaily
+
+- Data range: 1998-07-01 ~ now
+- Data update time: **Monday to Friday 16:30**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futures_daily(
+            futures_id='TX',
+            start_date='2020-04-01',
+            end_date='2020-04-12',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesDaily",
+            "data_id":"TX",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesDaily",
+                data_id="TX",
+                start_date= "2020-04-01",
+                end_date= "2020-04-12"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_futures_daily(
+            futures_id_list=['TXF', 'MXF', 'EXF'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       | futures_id   |   contract_date |   open |   max |   min |   close |   spread |   spread_per |   volume |   settlement_price |   open_interest | trading_session   |
+        |---:|:-----------|:-------------|----------------:|-------:|------:|------:|--------:|---------:|-------------:|---------:|-------------------:|----------------:|:------------------|
+        |  0 | 2020-04-01 | TX           |          202004 |   9588 |  9650 |  9551 |    9552 |      -43 |        -0.45 |   116273 |               9555 |           83725 | position          |
+        |  1 | 2020-04-01 | TX           |          202004 |   9630 |  9665 |  9551 |    9575 |      -20 |        -0.21 |    73771 |                  0 |               0 | after_market      |
+        |  2 | 2020-04-01 | TX           |          202005 |   9523 |  9580 |  9484 |    9486 |      -43 |        -0.45 |     1266 |               9486 |            6435 | position          |
+        |  3 | 2020-04-01 | TX           |          202005 |   9565 |  9595 |  9486 |    9526 |       -3 |        -0.03 |      452 |                  0 |               0 | after_market      |
+        |  4 | 2020-04-01 | TX           |          202006 |   9452 |  9508 |  9415 |    9419 |      -36 |        -0.38 |      106 |               9419 |            5547 | position          |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            futures_id: str, # futures code
+            contract_date: str, # contract month
+            open: float32, # open price
+            max: float32, # max price
+            min: float32, # min price
+            close: float32, # close price
+            spread: float32, # price change
+            spread_per: float32, # price change percentage
+            volume: float64, # trading volume
+            settlement_price: float32, # settlement price
+            open_interest: float64, # open interest
+            trading_session: str # trading session
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futures_daily(
+            start_date='2020-04-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesDaily",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesDaily",
+                start_date= "2020-04-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('rbind',data$data) %>%data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    | date       | futures_id   |   contract_date |   open |   max |   min |   close |   spread |   spread_per |   volume |   settlement_price |   open_interest | trading_session   |
+        |---:|:-----------|:-------------|----------------:|-------:|------:|------:|--------:|---------:|-------------:|---------:|-------------------:|----------------:|:------------------|
+        |  0 | 2020-04-01 | BRF          |          202005 |      0 |     0 |   0   |     0   |        0 |         0    |        0 |              681   |             381 | position          |
+        |  1 | 2020-04-01 | BRF          |          202005 |    690 |   704 | 681   |   681   |       -9 |        -1.3  |       45 |                0   |               0 | after_market      |
+        |  2 | 2020-04-01 | BRF          |          202006 |    795 |   799 | 774   |   774   |      -30 |        -3.73 |       63 |              774   |             435 | position          |
+        |  3 | 2020-04-01 | BRF          |          202006 |    818 |   833 | 789.5 |   791   |      -13 |        -1.62 |       77 |                0   |               0 | after_market      |
+        |  4 | 2020-04-01 | BRF          |          202007 |    881 |   881 | 874.5 |   874.5 |        7 |         0.81 |        3 |              874.5 |               3 | position          |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            futures_id: str, # futures code
+            contract_date: str, # contract month
+            open: float32, # open price
+            max: float32, # max price
+            min: float32, # min price
+            close: float32, # close price
+            spread: float32, # price change
+            spread_per: float32, # price change percentage
+            volume: float64, # trading volume
+            settlement_price: float32, # settlement price
+            open_interest: float64, # open interest
+            trading_session: str # trading session
+        }
+        ```
+
+----------------------------------
+#### Options Daily Trading Information TaiwanOptionDaily
+
+- Data range: 2001-12-01 ~ now
+- Data update time: **Monday to Friday 16:30**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_option_daily(
+            option_id='TXO',
+            start_date='2020-04-01',
+            end_date='2020-04-02',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionDaily",
+            "data_id":"TXO",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-02",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionDaily",
+                data_id="TXO",
+                start_date= "2020-04-01",
+                end_date= "2020-04-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('rbind',data$data) %>%data.table
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_option_daily(
+            option_id_list=['TXO', 'TEO'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       | option_id   |   contract_date |   strike_price | call_put   |   open |   max |   min |   close |   volume |   settlement_price |   open_interest | trading_session   |
+        |---:|:-----------|:------------|----------------:|---------------:|:-----------|-------:|------:|------:|--------:|---------:|-------------------:|----------------:|:------------------|
+        |  0 | 2020-04-01 | TXO         |          202004W1 |             8300 | put        |   0.1 |  0.2 |  0.1 |    0.1 |      325 |               0 |            6253 | position          |
+        |  1 | 2020-04-01 | TXO         |          202004W1 |             8300 | put       |   0.2    |  0.2    |  0.1    |    0.2    |   382 |              0  |               0 | after_market          |
+        |  2 | 2020-04-01 | TXO         |          202004W1 |             8400 | put        |   0.1    |  0.1    |  0.1    |    0.1    |   152 |               0 |            1710 | position          |
+        |  3 | 2020-04-01 | TXO         |          202004W1 |             8400 | put       |   0.3    |  0.3    |  0.1    |    0.1    |       96 |              0  |               0 | after_market          |
+        |  4 | 2020-04-01 | TXO         |          202004W1 |             8500 | put        |   0.1    |  0.1    |  0.1    |    0.1    |       94 |               0 |               3464 | position          |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            option_id: str, # option code
+            contract_date: str, # contract month
+            strike_price:float32, # strike price
+            call_put: str, # call/put
+            open: float32, # open price
+            max: float32, # max price
+            min: float32, # min price
+            close: float32, # close price
+            volume: float64, # trading volume
+            settlement_price: float32, # settlement price
+            open_interest: float64, # open interest
+            trading_session: str # trading session
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_option_daily(
+            start_date='2020-04-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionDaily",
+            "start_date": "2020-04-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionDaily",
+                start_date= "2020-04-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('rbind',data$data) %>%data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       | option_id   |   contract_date |   strike_price | call_put   |   open |   max |   min |   close |   volume |   settlement_price |   open_interest | trading_session   |
+        |---:|:-----------|:------------|----------------:|---------------:|:-----------|-------:|------:|------:|--------:|---------:|-------------------:|----------------:|:------------------|
+        |  0 | 2020-04-01 | CAO         |          202004 |             55 | put        |   2.22 |  2.22 |  2.22 |    2.22 |        5 |               2.48 |              15 | position          |
+        |  1 | 2020-04-01 | CAO         |          202004 |             40 | call       |   0    |  0    |  0    |    0    |        0 |              13.7  |               0 | position          |
+        |  2 | 2020-04-01 | CAO         |          202004 |             40 | put        |   0    |  0    |  0    |    0    |        0 |               0.01 |               0 | position          |
+        |  3 | 2020-04-01 | CAO         |          202004 |             41 | call       |   0    |  0    |  0    |    0    |        0 |              12.7  |               0 | position          |
+        |  4 | 2020-04-01 | CAO         |          202004 |             41 | put        |   0    |  0    |  0    |    0    |        0 |               0.01 |               0 | position          |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            option_id: str, # option code
+            contract_date: str, # contract month
+            strike_price: float32, # strike price
+            call_put: str, # call/put
+            open: float32, # open price
+            max: float32, # max price
+            min: float32, # min price
+            close: float32, # close price
+            volume: float64, # trading volume
+            settlement_price: float32, # settlement price
+            open_interest: float64, # open interest
+            trading_session: str # trading session
+        }
+        ```
+
+----------------------------------
+#### Futures Trading Detail Table TaiwanFuturesTick (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Due to the large data volume, each request only provides one day's data.
+- Data range: 2011-01-03 ~ now
+- Data update time: **Monday to Friday 6:00**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futures_tick(
+            futures_id='MTX',
+            date='2020-04-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesTick",
+            "data_id": "MTX",
+            "start_date": "2020-04-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesTick",
+                data_id="MTX",
+                start_date= "2020-01-02",
+                token = "" # Refer to login to obtain the token
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    |   contract_date | date                | futures_id   |   price |   volume |
+        |---:|----------------:|:--------------------|:-------------|--------:|---------:|
+        |  0 |          202004 | 2020-04-01 00:00:01 | MTX          |    9641 |        2 |
+        |  1 |          202004 | 2020-04-01 00:00:01 | MTX          |    9641 |        2 |
+        |  2 |          202004 | 2020-04-01 00:00:01 | MTX          |    9641 |        6 |
+        |  3 |          202004 | 2020-04-01 00:00:02 | MTX          |    9640 |        2 |
+        |  4 |          202004 | 2020-04-01 00:00:02 | MTX          |    9640 |        2 |
+    === "Schema"
+        ```
+        {
+            ExercisePrice: float32,
+            PutCall: str, # call/put
+            contract_date: str, # contract month
+            date: str, # date
+            futures_id: str, # futures code
+            price: float32, # deal price
+            volume: int32 # volume
+        }
+        ```
+
+----------------------------------
+#### Options Trading Detail Table TaiwanOptionTick (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Due to the large data volume, each request only provides one day's data.
+- Data range: 2011-01-03 ~ now (data is incomplete between 2019-01-16 and 2019-06-30).
+- Data update time: **Monday to Friday 6:00**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_option_tick(
+            option_id='OCO',
+            date='2020-04-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionTick",
+            "data_id": "OCO",
+            "start_date": "2019-09-05",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionTick",
+                data_id="OCO",
+                start_date= "2019-09-05",
+                token = "" # Refer to login to obtain the token
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        date = '2025-12-08'
+        start = datetime.datetime.now()
+        df = api.taiwan_option_tick(
+            option_id_list=['TXO', 'TEO'],
+            date=date,
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   ExercisePrice | PutCall   |   contract_date | date                | option_id   |   price |   volume |
+        |---:|----------------:|:----------|----------------:|:--------------------|:------------|--------:|---------:|
+        |  0 |            20.5 | P         |          202004 | 2020-04-01 10:26:58 | OCO         |    0.29 |        1 |
+        |  1 |            20.5 | P         |          202004 | 2020-04-01 10:26:58 | OCO         |    0.29 |        1 |
+        |  2 |            21   | P         |          202004 | 2020-04-01 10:26:58 | OCO         |    0.44 |        2 |
+        |  3 |            21   | P         |          202004 | 2020-04-01 10:26:58 | OCO         |    0.44 |        2 |
+        |  4 |            21   | P         |          202004 | 2020-04-01 10:26:58 | OCO         |    0.44 |        4 |
+    === "Schema"
+        ```
+        {
+            ExercisePrice: float32,
+            PutCall: str, # call/put
+            contract_date: str, # contract month
+            date: str, # date
+            option_id: str, # option code
+            price: float32, # deal price
+            volume: int32 # volume
+        }
+        ```
+
+----------------------------------
+#### Futures Top Three Institutional Investors Trading TaiwanFuturesInstitutionalInvestors
+
+- Data range: 2018-06-05 ~ now
+- Data update time: **Monday to Friday 18:00**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futures_institutional_investors(
+            data_id='TX',
+            start_date='2020-04-01',
+            end_date='2020-04-12',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesInstitutionalInvestors",
+            "data_id": "TX",# "TXO"
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        print(df.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesInstitutionalInvestors",
+                data_id="TX",
+                start_date= "2020-04-01",
+                end_date= "2020-04-12",
+                token = "" # Refer to login to obtain the token
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_futures_institutional_investors(
+            futures_id_list=['TXF', 'MXF', 'EXF'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | name   | date       | institutional_investors   |   long_deal_volume |   long_deal_amount |   short_deal_volume |   short_deal_amount |   long_open_interest_balance_volume |   long_open_interest_balance_amount |   short_open_interest_balance_volume |   short_open_interest_balance_amount |
+        |---:|:-------|:-----------|:--------------------------|-------------------:|-------------------:|--------------------:|--------------------:|------------------------------------:|------------------------------------:|-------------------------------------:|-------------------------------------:|
+        |  0 | TX     | 2020-04-01 | 自營商                    |              15050 |           28875620 |               15325 |            29415959 |                               19022 |                            36062632 |                                15962 |                             30209225 |
+        |  1 | TX     | 2020-04-01 | 外資                      |              79042 |          151832089 |               75938 |           145876617 |                               65435 |                           124990394 |                                14318 |                             27292956 |
+        |  2 | TX     | 2020-04-01 | 投信                      |                 30 |              57341 |                1313 |             2510881 |                                3770 |                             7204470 |                                37345 |                             71365191 |
+        |  3 | TX     | 2020-04-06 | 自營商                    |              15412 |           29817592 |               14569 |            28153648 |                               19528 |                            38087211 |                                15628 |                             30423409 |
+        |  4 | TX     | 2020-04-06 | 投信                      |               1135 |            2226831 |                  53 |              102477 |                                3800 |                             7465480 |                                36293 |                             71299930 |
+    === "Schema"
+        ```
+        {
+            name: str, # product name
+            date: str, # date
+            institutional_investors: str, # investor type
+            long_deal_volume: int32, # long-side trading volume (lots)
+            long_deal_amount: int32, # long-side contract amount
+            short_deal_volume: int32, # short-side trading volume (lots)
+            short_deal_amount: int32, # short-side contract amount
+            long_open_interest_balance_volume: int32, # long-side open interest (lots)
+            long_open_interest_balance_amount: int32, # long-side open interest contract amount
+            short_open_interest_balance_volume: int32, # short-side open interest (lots)
+            short_open_interest_balance_amount: int32 # short-side open interest contract amount
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futopt_institutional_investors(
+            start_date='2020-04-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesInstitutionalInvestors",
+            "start_date": "2019-04-03",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        print(df)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesInstitutionalInvestors",
+                start_date= "2019-04-03"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('rbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    | name   | date       | institutional_investors   |   long_deal_volume |   long_deal_amount |   short_deal_volume |   short_deal_amount |   long_open_interest_balance_volume |   long_open_interest_balance_amount |   short_open_interest_balance_volume |   short_open_interest_balance_amount |
+        |---:|:-------|:-----------|:--------------------------|-------------------:|-------------------:|--------------------:|--------------------:|------------------------------------:|------------------------------------:|-------------------------------------:|-------------------------------------:|
+        |  0 | ETF    | 2020-04-01 | 外資                      |                782 |             492994 |                 840 |              541759 |                                4462 |                             3167434 |                                 2552 |                               846756 |
+        |  1 | ETF    | 2020-04-01 | 投信                      |                  0 |                  0 |                   0 |                   0 |                                2702 |                             1071881 |                                 4079 |                              2791150 |
+        |  2 | ETF    | 2020-04-01 | 自營商                    |                405 |             151407 |                 431 |              161203 |                                4493 |                             2209637 |                                 4931 |                              2386376 |
+        |  3 | ETO    | 2020-04-01 | 投信                      |                  0 |                  0 |                   0 |                   0 |                                   0 |                                   0 |                                    0 |                                    0 |
+        |  4 | ETO    | 2020-04-01 | 外資                      |                  0 |                  0 |                   0 |                   0 |                                   0 |                                   0 |                                    0 |                                    0 |
+    === "Schema"
+        ```
+        {
+            name: str, # product name
+            date: str, # date
+            institutional_investors: str, # investor type
+            long_deal_volume: int32, # long-side trading volume (lots)
+            long_deal_amount: int32, # long-side contract amount
+            short_deal_volume: int32, # short-side trading volume (lots)
+            short_deal_amount: int32, # short-side contract amount
+            long_open_interest_balance_volume: int32, # long-side open interest (lots)
+            long_open_interest_balance_amount: int32, # long-side open interest contract amount
+            short_open_interest_balance_volume: int32, # short-side open interest (lots)
+            short_open_interest_balance_amount: int32 # short-side open interest contract amount
+        }
+        ```
+
+----------------------------------
+#### Options Top Three Institutional Investors Trading TaiwanOptionInstitutionalInvestors
+
+- Data range: 2018-06-05 ~ now
+- Data update time: **Monday to Friday 16:00**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_option_institutional_investors(
+            data_id='TXO',
+            start_date='2020-04-01',
+            end_date='2020-04-12',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionInstitutionalInvestors",
+            "data_id": "TXO",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        print(df)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionInstitutionalInvestors",
+                data_id="TX",# "TXO"
+                start_date= "2020-04-01",
+                end_date= "2020-04-12",
+                token = "" # Refer to login to obtain the token
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_option_institutional_investors(
+            option_id_list=['TXO', 'TEO'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | name   | date       | call_put   |  institutional_investors   |   long_deal_volume |   long_deal_amount |   short_deal_volume |   short_deal_amount |   long_open_interest_balance_volume |   long_open_interest_balance_amount |   short_open_interest_balance_volume |   short_open_interest_balance_amount |
+        |---:|:-------|:-----------|:-----------|:--------------------------|-------------------:|-------------------:|--------------------:|--------------------:|------------------------------------:|------------------------------------:|-------------------------------------:|-------------------------------------:|
+        |  0 | TXO    | 2020-04-01 | 買權  | 自營商                    |             139973 |             370181 |              163094 |              356201 |                               58152 |                              504601 |                                81614 |                               517097 |
+        |  1 | TXO    | 2020-04-01 | 買權  | 投信                      |                  0 |                  0 |                   0 |                   0 |                                   0 |                                   0 |                                    0 |                                    0 |
+        |  2 | TXO    | 2020-04-01 | 買權  | 外資                      |              69409 |             214529 |               61586 |              224112 |                               75953 |                              630438 |                                55645 |                               586723 |
+        |  3 | TXO    | 2020-04-06 | 買權  | 自營商                    |             124528 |             453602 |              132575 |              475720 |                               67677 |                              646018 |                                99186 |                               671818 |
+        |  4 | TXO    | 2020-04-06 | 賣權  | 投信                      |                  0 |                  0 |                   0 |                   0 |                                   0 |                                   0 |                                    0 |                                    0 |
+    === "Schema"
+        ```
+        {
+            name: str, # product name
+            date: str, # date
+            call_put: str, # call/put
+            institutional_investors: str, # investor type
+            long_deal_volume: int32, # long-side trading volume (lots)
+            long_deal_amount: int32, # long-side contract amount
+            short_deal_volume: int32, # short-side trading volume (lots)
+            short_deal_amount: int32, # short-side contract amount
+            long_open_interest_balance_volume: int32, # long-side open interest (lots)
+            long_open_interest_balance_amount: int32, # long-side open interest contract amount
+            short_open_interest_balance_volume: int32, # short-side open interest (lots)
+            short_open_interest_balance_amount: int32 # short-side open interest contract amount
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futopt_institutional_investors(
+            data_id='TXO',
+            start_date='2020-04-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionInstitutionalInvestors",
+            "start_date": "2019-04-03",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        print(df)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionInstitutionalInvestors",
+                start_date= "2019-04-03"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('rbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    | name   | date       | institutional_investors   |   long_deal_volume |   long_deal_amount |   short_deal_volume |   short_deal_amount |   long_open_interest_balance_volume |   long_open_interest_balance_amount |   short_open_interest_balance_volume |   short_open_interest_balance_amount |
+        |---:|:-------|:-----------|:--------------------------|-------------------:|-------------------:|--------------------:|--------------------:|------------------------------------:|------------------------------------:|-------------------------------------:|-------------------------------------:|
+        |  0 | TXO    | 2020-04-01 | 自營商                    |             139973 |             370181 |              163094 |              356201 |                               58152 |                              504601 |                                81614 |                               517097 |
+        |  1 | TXO    | 2020-04-01 | 投信                      |                  0 |                  0 |                   0 |                   0 |                                   0 |                                   0 |                                    0 |                                    0 |
+        |  2 | TXO    | 2020-04-01 | 外資                      |              69409 |             214529 |               61586 |              224112 |                               75953 |                              630438 |                                55645 |                               586723 |
+        |  3 | TXO    | 2020-04-06 | 自營商                    |             124528 |             453602 |              132575 |              475720 |                               67677 |                              646018 |                                99186 |                               671818 |
+        |  4 | TXO    | 2020-04-06 | 投信                      |                  0 |                  0 |                   0 |                   0 |                                   0 |                                   0 |                                    0 |                                    0 |
+    === "Schema"
+        ```
+        {
+            name: str, # product name
+            date: str, # date
+            call_put: str, # call/put
+            institutional_investors: str, # investor type
+            long_deal_volume: int32, # long-side trading volume (lots)
+            long_deal_amount: int32, # long-side contract amount
+            short_deal_volume: int32, # short-side trading volume (lots)
+            short_deal_amount: int32, # short-side contract amount
+            long_open_interest_balance_volume: int32, # long-side open interest (lots)
+            long_open_interest_balance_amount: int32, # long-side open interest contract amount
+            short_open_interest_balance_volume: int32, # short-side open interest (lots)
+            short_open_interest_balance_amount: int32 # short-side open interest contract amount
+        }
+        ```
+
+----------------------------------
+
+#### Futures After-Hours Top Three Institutional Investors Trading TaiwanFuturesInstitutionalInvestorsAfterHours (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2021-10-12 ~ now
+- Data update time: **Monday to Saturday 05:00**. The actual update time is based on the API data.
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesInstitutionalInvestorsAfterHours",
+            "data_id": "TX",
+            "start_date": "2021-10-12",
+            "end_date": "2024-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        print(df.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesInstitutionalInvestorsAfterHours",
+                data_id="TX",
+                start_date= "2021-10-12",
+                end_date= "2024-04-12"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_futures_institutional_investors_after_hours(
+            futures_id_list=['TXF', 'MXF', 'EXF'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | futures_id   | date       | institutional_investors   |   long_deal_volume |   long_deal_amount |   short_deal_volume |   short_deal_amount |
+        |---:|:-------------|:-----------|:--------------------------|-------------------:|-------------------:|--------------------:|--------------------:|
+        |  0 | TX           | 2021-10-12 | 自營商                    |               1690 |            5615098 |                1516 |             5034732 |
+        |  1 | TX           | 2021-10-12 | 投信                      |                  0 |                  0 |                   0 |                   0 |
+        |  2 | TX           | 2021-10-12 | 外資                      |              16315 |           54215114 |               14737 |            48973486 |
+        |  3 | TX           | 2021-10-13 | 自營商                    |               2307 |            7608759 |                2252 |             7427497 |
+        |  4 | TX           | 2021-10-13 | 投信                      |                  0 |                  0 |                   0 |                   0 |
+    === "Schema"
+        ```
+        {
+            name: str, # product name
+            date: str, # date
+            institutional_investors: str, # investor type
+            long_deal_volume: int32, # long-side trading volume (lots)
+            long_deal_amount: int32, # long-side contract amount
+            short_deal_volume: int32, # short-side trading volume (lots)
+            short_deal_amount: int32 # short-side contract amount
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesInstitutionalInvestorsAfterHours",
+            "start_date": "2021-10-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        print(df)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesInstitutionalInvestorsAfterHours",
+                start_date= "2021-10-12"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('rbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    | futures_id   | date       | institutional_investors   |   long_deal_volume |   long_deal_amount |   short_deal_volume |   short_deal_amount |
+        |---:|:-------------|:-----------|:--------------------------|-------------------:|-------------------:|--------------------:|--------------------:|
+        |  0 | F1F          | 2021-10-12 | 自營商                    |                 39 |              13769 |                  41 |               14477 |
+        |  1 | F1F          | 2021-10-12 | 投信                      |                  0 |                  0 |                   0 |                   0 |
+        |  2 | F1F          | 2021-10-12 | 外資                      |                 83 |              29320 |                  35 |               12349 |
+        |  3 | MTX          | 2021-10-12 | 自營商                    |               2454 |            2037796 |                2761 |             2292564 |
+        |  4 | MTX          | 2021-10-12 | 投信                      |                  0 |                  0 |                   0 |                   0 |
+    === "Schema"
+        ```
+        {
+            name: str, # product name
+            date: str, # date
+            institutional_investors: str, # investor type
+            long_deal_volume: int32, # long-side trading volume (lots)
+            long_deal_amount: int32, # long-side contract amount
+            short_deal_volume: int32, # short-side trading volume (lots)
+            short_deal_amount: int32 # short-side contract amount
+        }
+        ```
+
+----------------------------------
+#### Options After-Hours Top Three Institutional Investors Trading TaiwanOptionInstitutionalInvestorsAfterHours (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2021-10-12 ~ now
+- Data update time: **Monday to Saturday 05:00**. The actual update time is based on the API data.
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionInstitutionalInvestorsAfterHours",
+            "data_id": "TXO",
+            "start_date": "2021-10-12",
+            "end_date": "2024-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        print(df)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionInstitutionalInvestorsAfterHours",
+                data_id="TXO",
+                start_date= "2021-10-12",
+                end_date= "2024-04-12"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_option_institutional_investors_after_hours(
+            option_id_list=['TXO', 'TEO'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | option_id   | date       | call_put   | institutional_investors   |   long_deal_volume |   long_deal_amount |   short_deal_volume |   short_deal_amount |
+        |---:|:------------|:-----------|:-----------|:--------------------------|-------------------:|-------------------:|--------------------:|--------------------:|
+        |  0 | TXO         | 2021-10-12 | CALL       | 自營商                    |              14018 |              45608 |               14478 |               48062 |
+        |  1 | TXO         | 2021-10-12 | CALL       | 投信                      |                  0 |                  0 |                   0 |                   0 |
+        |  2 | TXO         | 2021-10-12 | CALL       | 外資                      |              16060 |              78585 |               14961 |               68018 |
+        |  3 | TXO         | 2021-10-12 | PUT        | 自營商                    |              12802 |              50821 |               15570 |               66005 |
+        |  4 | TXO         | 2021-10-12 | PUT        | 投信                      |                  0 |                  0 |                   0 |                   0 |
+    === "Schema"
+        ```
+        {
+            name: str, # product name
+            date: str, # date
+            call_put: str, # call/put
+            institutional_investors: str, # investor type
+            long_deal_volume: int32, # long-side trading volume (lots)
+            long_deal_amount: int32, # long-side contract amount
+            short_deal_volume: int32, # short-side trading volume (lots)
+            short_deal_amount: int32, # short-side contract amount
+            long_open_interest_balance_volume: int32, # long-side open interest (lots)
+            long_open_interest_balance_amount: int32, # long-side open interest contract amount
+            short_open_interest_balance_volume: int32, # short-side open interest (lots)
+            short_open_interest_balance_amount: int32 # short-side open interest contract amount
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionInstitutionalInvestorsAfterHours",
+            "start_date": "2021-10-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        print(df)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionInstitutionalInvestorsAfterHours",
+                start_date= "2021-10-12"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('rbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    | option_id   | date       | call_put   | institutional_investors   |   long_deal_volume |   long_deal_amount |   short_deal_volume |   short_deal_amount |
+        |---:|:------------|:-----------|:-----------|:--------------------------|-------------------:|-------------------:|--------------------:|--------------------:|
+        |  0 | TXO         | 2021-10-12 | CALL       | 自營商                    |              14018 |              45608 |               14478 |               48062 |
+        |  1 | TXO         | 2021-10-12 | CALL       | 投信                      |                  0 |                  0 |                   0 |                   0 |
+        |  2 | TXO         | 2021-10-12 | CALL       | 外資                      |              16060 |              78585 |               14961 |               68018 |
+        |  3 | TXO         | 2021-10-12 | PUT        | 自營商                    |              12802 |              50821 |               15570 |               66005 |
+        |  4 | TXO         | 2021-10-12 | PUT        | 投信                      |                  0 |                  0 |                   0 |                   0 |
+    === "Schema"
+        ```
+        {
+            name: str, # product name
+            date: str, # date
+            call_put: str, # call/put
+            institutional_investors: str, # investor type
+            long_deal_volume: int32, # long-side trading volume (lots)
+            long_deal_amount: int32, # long-side contract amount
+            short_deal_volume: int32, # short-side trading volume (lots)
+            short_deal_amount: int32 # short-side contract amount
+        }
+        ```
+
+----------------------------------
+#### Futures Daily Trading Volume by Dealer TaiwanFuturesDealerTradingVolumeDaily
+
+- Data range: 2021-04-01 ~ now
+- Data update time: **Monday to Friday 19:00**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futures_dealer_trading_volume_daily(
+            futures_id='TX',
+            start_date='2020-07-01',
+            end_date='2020-07-12',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesDealerTradingVolumeDaily",
+            "data_id": "TX",
+            "start_date": "2020-07-01",
+            "end_date": "2020-10-02",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        print(df.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesDealerTradingVolumeDaily",
+                data_id="TX",
+                start_date="2020-07-01",
+                end_date="2020-10-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_futures_dealer_trading_volume_daily(
+            futures_id_list=['TXF', 'MXF', 'EXF'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       | dealer_code   | dealer_name          | futures_id   |   volume | is_after_hour   |
+        |---:|:-----------|:--------------|:---------------------|:-------------|---------:|:----------------|
+        |  0 | 2020-07-01 | B224999       | 中國信託商業銀行自營 | TX           |     1500 | False           |
+        |  1 | 2020-07-01 | F001000       | 國泰期貨             | TX           |     1789 | False           |
+        |  2 | 2020-07-01 | F002000       | 永豐期貨             | TX           |     9664 | False           |
+        |  3 | 2020-07-01 | F002999       | 永豐期貨自營         | TX           |        0 | False           |
+        |  4 | 2020-07-01 | F004000       | 凱基期貨             | TX           |    43882 | False           |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            dealer_code: str, # dealer code
+            dealer_name: str, # dealer name
+            futures_id: str, # futures code
+            volume: int32, # trading volume
+            is_after_hour: int32 # after-hours trading
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futures_dealer_trading_volume_daily(
+            start_date='2021-07-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesDealerTradingVolumeDaily",
+            "start_date": "2020-07-01",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        df
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesDealerTradingVolumeDaily",
+                start_date="2020-07-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('rbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    | date       | dealer_code   | dealer_name   | futures_id   |   volume | is_after_hour   |
+        |---:|:-----------|:--------------|:--------------|:-------------|---------:|:----------------|
+        |  0 | 2021-07-01 | F021000       | 元大期貨      | BRF          |        0 | True            |
+        |  1 | 2021-07-01 | F004000       | 凱基期貨      | BRF          |        0 | True            |
+        |  2 | 2021-07-01 | F020000       | 群益期貨      | BRF          |        0 | True            |
+        |  3 | 2021-07-01 | F002000       | 永豐期貨      | BRF          |        0 | True            |
+        |  4 | 2021-07-01 | F008000       | 統一期貨      | BRF          |        1 | True            |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            dealer_code: str, # dealer code
+            dealer_name: str, # dealer name
+            futures_id: str, # futures code
+            volume: int32, # trading volume
+            is_after_hour: int32 # after-hours trading
+        }
+        ```
+
+----------------------------------
+#### Options Daily Trading Volume by Dealer TaiwanOptionDealerTradingVolumeDaily
+
+- Data range: 2021-04-01 ~ now
+- Data update time: **Monday to Friday 18:00**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_option_dealer_trading_volume_daily(
+            option_id='TXO',
+            start_date='2020-07-01',
+            end_date='2020-07-12',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionDealerTradingVolumeDaily",
+            "data_id": "TXO",
+            "start_date": "2020-07-01",
+            "end_date": "2020-10-02",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        df
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionDealerTradingVolumeDaily",
+                data_id="TXO",
+                start_date="2020-07-01",
+                end_date="2020-10-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_option_dealer_trading_volume_daily(
+            option_id_list=['TXO', 'TEO'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       | dealer_code   | dealer_name          | option_id   |   volume | is_after_hour   |
+        |---:|:-----------|:--------------|:---------------------|:------------|---------:|:----------------|
+        |  0 | 2020-07-01 | B224999       | 中國信託商業銀行自營 | TXO         |    13390 | False           |
+        |  1 | 2020-07-01 | F001000       | 國泰期貨             | TXO         |    17478 | False           |
+        |  2 | 2020-07-01 | F002000       | 永豐期貨             | TXO         |    75395 | False           |
+        |  3 | 2020-07-01 | F002999       | 永豐期貨自營         | TXO         |       98 | False           |
+        |  4 | 2020-07-01 | F004000       | 凱基期貨             | TXO         |   159164 | False           |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            dealer_code: str, # dealer code
+            dealer_name: str, # dealer name
+            option_id: str, # option code
+            volume: int32, # trading volume
+            is_after_hour: int32 # after-hours trading
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_option_dealer_trading_volume_daily(
+            start_date='2021-07-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionDealerTradingVolumeDaily",
+            "start_date": "2021-07-01",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        df
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionDealerTradingVolumeDaily",
+                start_date="2021-07-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('rbind',data$data) %>%data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       | dealer_code   | dealer_name      | option_id   |   volume | is_after_hour   |
+        |---:|:-----------|:--------------|:-----------------|:------------|---------:|:----------------|
+        |  0 | 2021-07-01 | F021000       | 元大期貨         | ETC         |        1 | False           |
+        |  1 | 2021-07-01 | F034999       | 澳帝華期貨自營   | ETC         |       42 | False           |
+        |  2 | 2021-07-01 | F004000       | 凱基期貨         | ETC         |        0 | False           |
+        |  3 | 2021-07-01 | S890999       | 法銀巴黎證券自營 | ETC         |       83 | False           |
+        |  4 | 2021-07-01 | F002000       | 永豐期貨         | ETC         |        0 | False           |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            dealer_code: str, # dealer code
+            dealer_name: str, # dealer name
+            option_id: str, # option code
+            volume: int32, # trading volume
+            is_after_hour: int32 # after-hours trading
+        }
+        ```
+
+#### Futures Open Interest of Large Traders TaiwanFuturesOpenInterestLargeTraders (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 1998-07-01 ~ now
+- Data update time: **Monday to Friday 16:30**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futures_open_interest_large_traders(
+            futures_id='TJF',
+            start_date='2024-09-01',
+            end_date='2024-09-02',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesOpenInterestLargeTraders",
+            "data_id":"TJF",
+            "start_date": "2024-09-01",
+            "end_date": "2024-09-02",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesOpenInterestLargeTraders",
+                data_id="TJF",
+                start_date= "2024-09-01",
+                end_date= "2024-09-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_futures_open_interest_large_traders(
+            futures_id_list=['TXF', 'MXF', 'EXF'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | name       | contract_type   |   buy_top5_trader_open_interest |   buy_top5_trader_open_interest_per |   buy_top10_trader_open_interest |   buy_top10_trader_open_interest_per |   sell_top5_trader_open_interest |   sell_top5_trader_open_interest_per |   sell_top10_trader_open_interest |   sell_top10_trader_open_interest_per |   market_open_interest |   buy_top5_specific_open_interest | buy_top5_specific_open_interest_per   |    buy_top10_specific_open_interest | buy_top10_specific_open_interest_per   |   sell_top5_specific_open_interest | sell_top5_specific_open_interest_per   |   sell_top10_specific_open_interest | sell_top10_specific_open_interest_per   |   date | futures_id   |
+        |---:|:-----------|:-------------|----------------:|-------:|------:|------:|--------:|---------:|-------------:|---------:|-------------------:|----------------:|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|
+        |  0 | 東證期貨 | 202409  | 93 |   74.4 |  113 |  90.4 |    102 |     81.6 |  118 |   94.4 |  125 |  16 | 12.8     | 16 | 12.8 | 14 | 11.2 | 14 | 11.2 | 2024-09-02 | TJF |
+        |  1 |  東證期貨 | 202409  | 133 |   62.7 |  170 |  80.2 |  172 |     81.1 |  194 |   91.5 |  212 |  16 | 7.5     | 16 | 7.5 | 42 | 19.8 | 42 | 19.5 | 2024-09-02 | TJF |
+    === "Schema"
+        ```
+        {
+            name: str, # product name
+            contract_type: str, # contract month
+            buy_top5_trader_open_interest: int32, # total open interest of top 5 buy-side traders
+            buy_top5_trader_open_interest_per: float32, # percentage of top 5 buy-side traders
+            buy_top10_trader_open_interest: int32, # total open interest of top 10 buy-side traders
+            buy_top10_trader_open_interest_per: float32, # percentage of top 10 buy-side traders
+            sell_top5_trader_open_interest: int32, # total open interest of top 5 sell-side traders
+            sell_top5_trader_open_interest_per: float32, # percentage of top 5 sell-side traders
+            sell_top10_trader_open_interest: int32, # total open interest of top 10 sell-side traders
+            sell_top10_trader_open_interest_per: float32, # percentage of top 10 sell-side traders
+            market_open_interest: int32, # total market open interest
+            buy_top5_specific_open_interest: int32, # total open interest of top 5 buy-side specific institutions
+            buy_top5_specific_open_interest_per: float32, # percentage of top 5 buy-side specific institutions
+            buy_top10_specific_open_interest: int32, # total open interest of top 10 buy-side specific institutions
+            buy_top10_specific_open_interest_per: float32, # percentage of top 10 buy-side specific institutions
+            sell_top5_specific_open_interest: int32, # total open interest of top 5 sell-side specific institutions
+            sell_top5_specific_open_interest_per: float32, # percentage of top 5 sell-side specific institutions
+            sell_top10_specific_open_interest: int32, # total open interest of top 10 sell-side specific institutions
+            sell_top10_specific_open_interest_per: float32, # percentage of top 10 sell-side specific institutions
+            date: str, # date
+            futures_id: str # futures code
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futures_open_interest_large_traders(
+            start_date='2024-09-02'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesOpenInterestLargeTraders",
+            "start_date": "2024-09-02",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesOpenInterestLargeTraders",
+                start_date= "2024-09-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('rbind',data$data) %>%data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    | name       | contract_type   |   buy_top5_trader_open_interest |   buy_top5_trader_open_interest_per |   buy_top10_trader_open_interest |   buy_top10_trader_open_interest_per |   sell_top5_trader_open_interest |   sell_top5_trader_open_interest_per |   sell_top10_trader_open_interest |   sell_top10_trader_open_interest_per |   market_open_interest |   buy_top5_specific_open_interest | buy_top5_specific_open_interest_per   |    buy_top10_specific_open_interest | buy_top10_specific_open_interest_per   |   sell_top5_specific_open_interest | sell_top5_specific_open_interest_per   |   sell_top10_specific_open_interest | sell_top10_specific_open_interest_per   |   date | futures_id   |
+        |---:|:-----------|:-------------|----------------:|-------:|------:|------:|--------:|---------:|-------------:|---------:|-------------------:|----------------:|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|
+        |  0 |  布蘭特原油期貨  | 202411  | 40  | 100 |  40 | 100 | 40 | 100 |  40 | 100 | 40 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | BRF |
+        |  1 |  布蘭特原油期貨  | all  | 155  | 96.9 |  160 | 100 | 160 | 100 |  160 | 100 | 160 |  0 | 0  | 0 | 0 | 120 | 75 | 120 | 75 | 2024-09-02 | BRF |
+        |  2 |  臺灣生技期貨  | 202409  | 15  | 78.9 |  19 | 100 | 19 | 100 |  19 | 100 | 19 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | BTF |
+        |  3 |  臺灣生技期貨  | all  | 16  | 80 |  20 | 100 | 20 | 100 |  20 | 100 | 20 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | BTF |
+        |  4 |  南亞期貨  | 202409  | 231  | 30.3 |  332 | 43.6 | 512 | 67.2 |  655 | 86 | 762 |  127 | 16.7  | 127 | 16.7 | 438 | 57.5 | 532 | 69.8 | 2024-09-02 | CA |
+    === "Schema"
+        ```
+        {
+            name: str, # product name
+            contract_type: str, # contract month
+            buy_top5_trader_open_interest: int32, # total open interest of top 5 buy-side traders
+            buy_top5_trader_open_interest_per: float32, # percentage of top 5 buy-side traders
+            buy_top10_trader_open_interest: int32, # total open interest of top 10 buy-side traders
+            buy_top10_trader_open_interest_per: float32, # percentage of top 10 buy-side traders
+            sell_top5_trader_open_interest: int32, # total open interest of top 5 sell-side traders
+            sell_top5_trader_open_interest_per: float32, # percentage of top 5 sell-side traders
+            sell_top10_trader_open_interest: int32, # total open interest of top 10 sell-side traders
+            sell_top10_trader_open_interest_per: float32, # percentage of top 10 sell-side traders
+            market_open_interest: int32, # total market open interest
+            buy_top5_specific_open_interest: int32, # total open interest of top 5 buy-side specific institutions
+            buy_top5_specific_open_interest_per: float32, # percentage of top 5 buy-side specific institutions
+            buy_top10_specific_open_interest: int32, # total open interest of top 10 buy-side specific institutions
+            buy_top10_specific_open_interest_per: float32, # percentage of top 10 buy-side specific institutions
+            sell_top5_specific_open_interest: int32, # total open interest of top 5 sell-side specific institutions
+            sell_top5_specific_open_interest_per: float32, # percentage of top 5 sell-side specific institutions
+            sell_top10_specific_open_interest: int32, # total open interest of top 10 sell-side specific institutions
+            sell_top10_specific_open_interest_per: float32, # percentage of top 10 sell-side specific institutions
+            date: str, # date
+            futures_id: str # futures code
+        }
+        ```
+
+----------------------------------
+
+#### Options Open Interest of Large Traders TaiwanOptionOpenInterestLargeTraders (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 1998-07-01 ~ now
+- Data update time: **Monday to Friday 16:30**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_option_open_interest_large_traders(
+            futures_id='CA',
+            start_date='2024-09-01',
+            end_date='2024-09-02',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionOpenInterestLargeTraders",
+            "data_id":"CA",
+            "start_date": "2024-09-01",
+            "end_date": "2024-09-02",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionOpenInterestLargeTraders",
+                data_id="CA",
+                start_date= "2024-09-01",
+                end_date= "2024-09-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_option_open_interest_large_traders(
+            option_id_list=['TXO', 'TEO'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | contract_type   |   buy_top5_trader_open_interest |   buy_top5_trader_open_interest_per |   buy_top10_trader_open_interest |   buy_top10_trader_open_interest_per |   sell_top5_trader_open_interest |   sell_top5_trader_open_interest_per |   sell_top10_trader_open_interest |   sell_top10_trader_open_interest_per |   market_open_interest |   buy_top5_specific_open_interest | buy_top5_specific_open_interest_per   |    buy_top10_specific_open_interest | buy_top10_specific_open_interest_per   |   sell_top5_specific_open_interest | sell_top5_specific_open_interest_per   |   sell_top10_specific_open_interest | sell_top10_specific_open_interest_per   |   date | put_call | name   | option_id |
+        |---:|:-----------|:-------------|----------------:|-------:|------:|------:|--------:|---------:|-------------:|---------:|-------------------:|----------------:|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|
+        |  0 | 202409  | 0  | 0 |  0 | 0 | 0 | 0 |  0 | 0 | 0 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | call  | 南亞 | CA |
+        |  1 | all  | 0  | 0 |  0 | 0 | 0 | 0 |  0 | 0 | 0 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | call  | 南亞 | CA |
+        |  2 | 202409  |  0  | 0 |  0 | 0 | 0 | 0 |  0 | 0 | 0 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | put  | 南亞 | CA |
+        |  3 | all  | 0  | 0 |  0 | 0 | 0 | 0 |  0 | 0 | 0 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | put  | 南亞 | CA |
+    === "Schema"
+        ```
+        {
+            contract_type: str, # contract month
+            buy_top5_trader_open_interest: int32, # total open interest of top 5 buy-side traders
+            buy_top5_trader_open_interest_per: float32, # percentage of top 5 buy-side traders
+            buy_top10_trader_open_interest: int32, # total open interest of top 10 buy-side traders
+            buy_top10_trader_open_interest_per: float32, # percentage of top 10 buy-side traders
+            sell_top5_trader_open_interest: int32, # total open interest of top 5 sell-side traders
+            sell_top5_trader_open_interest_per: float32, # percentage of top 5 sell-side traders
+            sell_top10_trader_open_interest: int32, # total open interest of top 10 sell-side traders
+            sell_top10_trader_open_interest_per: float32, # percentage of top 10 sell-side traders
+            market_open_interest: int32, # total market open interest
+            buy_top5_specific_open_interest: int32, # total open interest of top 5 buy-side specific institutions
+            buy_top5_specific_open_interest_per: float32, # percentage of top 5 buy-side specific institutions
+            buy_top10_specific_open_interest: int32, # total open interest of top 10 buy-side specific institutions
+            buy_top10_specific_open_interest_per: float32, # percentage of top 10 buy-side specific institutions
+            sell_top5_specific_open_interest: int32, # total open interest of top 5 sell-side specific institutions
+            sell_top5_specific_open_interest_per: float32, # percentage of top 5 sell-side specific institutions
+            sell_top10_specific_open_interest: int32, # total open interest of top 10 sell-side specific institutions
+            sell_top10_specific_open_interest_per: float32, # percentage of top 10 sell-side specific institutions
+            date: str, # date
+            put_call: str, # call/put
+            name: str, # product name
+            option_id: str # option code
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_option_open_interest_large_traders(
+            start_date='2024-09-02'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionOpenInterestLargeTraders",
+            "start_date": "2024-09-02",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionOpenInterestLargeTraders",
+                start_date= "2024-09-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('rbind',data$data) %>%data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    | contract_type   |   buy_top5_trader_open_interest |   buy_top5_trader_open_interest_per |   buy_top10_trader_open_interest |   buy_top10_trader_open_interest_per |   sell_top5_trader_open_interest |   sell_top5_trader_open_interest_per |   sell_top10_trader_open_interest |   sell_top10_trader_open_interest_per |   market_open_interest |   buy_top5_specific_open_interest | buy_top5_specific_open_interest_per   |    buy_top10_specific_open_interest | buy_top10_specific_open_interest_per   |   sell_top5_specific_open_interest | sell_top5_specific_open_interest_per   |   sell_top10_specific_open_interest | sell_top10_specific_open_interest_per   |   date | put_call | name   | option_id |
+        |---:|:-----------|:-------------|----------------:|-------:|------:|------:|--------:|---------:|-------------:|---------:|-------------------:|----------------:|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|:------------------|
+        |  0 | 202409  | 0  | 0 |  0 | 0 | 0 | 0 |  0 | 0 | 0 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | call  | 南亞 | CA |
+        |  1 | all  | 0  | 0 |  0 | 0 | 0 | 0 |  0 | 0 | 0 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | call  | 南亞 | CA |
+        |  2 | 202409  |  0  | 0 |  0 | 0 | 0 | 0 |  0 | 0 | 0 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | put  | 南亞 | CA |
+        |  3 | all  | 0  | 0 |  0 | 0 | 0 | 0 |  0 | 0 | 0 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | put  | 南亞 | CA |
+        |  4 | 202409  | 0  | 0 |  0 | 0 | 0 | 0 |  0 | 0 | 0 |  0 | 0  | 0 | 0 | 0 | 0 | 0 | 0 | 2024-09-02 | call  | 中鋼 | CB |
+    === "Schema"
+        ```
+        {
+            contract_type: str, # contract month
+            buy_top5_trader_open_interest: int32, # total open interest of top 5 buy-side traders
+            buy_top5_trader_open_interest_per: float32, # percentage of top 5 buy-side traders
+            buy_top10_trader_open_interest: int32, # total open interest of top 10 buy-side traders
+            buy_top10_trader_open_interest_per: float32, # percentage of top 10 buy-side traders
+            sell_top5_trader_open_interest: int32, # total open interest of top 5 sell-side traders
+            sell_top5_trader_open_interest_per: float32, # percentage of top 5 sell-side traders
+            sell_top10_trader_open_interest: int32, # total open interest of top 10 sell-side traders
+            sell_top10_trader_open_interest_per: float32, # percentage of top 10 sell-side traders
+            market_open_interest: int32, # total market open interest
+            buy_top5_specific_open_interest: int32, # total open interest of top 5 buy-side specific institutions
+            buy_top5_specific_open_interest_per: float32, # percentage of top 5 buy-side specific institutions
+            buy_top10_specific_open_interest: int32, # total open interest of top 10 buy-side specific institutions
+            buy_top10_specific_open_interest_per: float32, # percentage of top 10 buy-side specific institutions
+            sell_top5_specific_open_interest: int32, # total open interest of top 5 sell-side specific institutions
+            sell_top5_specific_open_interest_per: float32, # percentage of top 5 sell-side specific institutions
+            sell_top10_specific_open_interest: int32, # total open interest of top 10 sell-side specific institutions
+            sell_top10_specific_open_interest_per: float32, # percentage of top 10 sell-side specific institutions
+            date: str, # date
+            put_call: str, # call/put
+            name: str, # product name
+            option_id: str # option code
+        }
+        ```
+
+----------------------------------
+#### Futures Spread Trading Quote Table TaiwanFuturesSpreadTrading (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2007-10-08 ~ now
+- Data update time: **Monday to Friday every 3 hours**. The actual update time is based on the API data.
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesSpreadTrading",
+            "data_id": "TX",
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesSpreadTrading",
+                data_id="TX",
+                start_date= "2024-01-01",
+                end_date= "2024-12-31"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_futures_spread_trading(
+            futures_id_list=['TXF', 'MXF', 'EXF'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       | futures_id | contract_date   | open  | max   | min   | close | best_bid | best_ask | historical_max | historical_min | spread_to_spread_volume | spread_to_single_volume | trading_session |
+        |---:|:-----------|:-----------|:----------------|:------|:------|:------|:------|:---------|:---------|:---------------|:---------------|:------------------------|:------------------------|:----------------|
+        |  0 | 2024-01-02 | TX         | 202401/202402   | -85.0 | -72.0 | -98.0 | -78.0 | -80.0    | -77.0    | 565.0          | -418.0         | 1234.0                  | 567.0                   | position        |
+        |  1 | 2024-01-02 | TX         | 202401/202403   | -90.0 | -80.0 | -105.0| -85.0 | -88.0    | -82.0    | 600.0          | -450.0         | 234.0                   | 123.0                   | position        |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            futures_id: str, # futures code
+            contract_date: str, # contract month
+            open: float64, # open price
+            max: float64, # max price
+            min: float64, # min price
+            close: float64, # close price
+            best_bid: float64, # best bid price
+            best_ask: float64, # best ask price
+            historical_max: float64, # historical max price
+            historical_min: float64, # historical min price
+            spread_to_spread_volume: float64, # spread-to-spread trading volume
+            spread_to_single_volume: float64, # spread-to-single trading volume
+            trading_session: str # trading session
+        }
+        ```
+
+----------------------------------
+#### Futures Final Settlement Price TaiwanFuturesFinalSettlementPrice (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 1998-01-01 ~ now
+- Data update time: **Monday to Friday every 3 hours**. The actual update time is based on the API data.
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFuturesFinalSettlementPrice",
+            "data_id": "TX",
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFuturesFinalSettlementPrice",
+                data_id="TX",
+                start_date= "2024-01-01",
+                end_date= "2024-12-31"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_futures_final_settlement_price(
+            futures_id_list=['TXF', 'MXF', 'EXF'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       | contract_month | futures_type | futures_id | futures_name | settlement_price | underlying_code | notional_value |
+        |---:|:-----------|:---------------|:-------------|:-----------|:-------------|:-----------------|:----------------|:---------------|
+        |  0 | 2024-01-17 | 202401         | index        | TX         | 臺股期貨     | 17881.0          |                 | 0.0            |
+        |  1 | 2024-02-21 | 202402         | index        | TX         | 臺股期貨     | 18658.0          |                 | 0.0            |
+        |  2 | 2024-03-20 | 202403         | index        | TX         | 臺股期貨     | 20199.0          |                 | 0.0            |
+    === "Schema"
+        ```
+        {
+            date: str, # expiration date
+            contract_month: str, # contract month
+            futures_type: str, # futures type (index/stock/commodity)
+            futures_id: str, # futures code
+            futures_name: str, # futures name
+            settlement_price: float64, # final settlement price
+            underlying_code: str, # underlying security code
+            notional_value: float64 # notional contract value
+        }
+        ```
+
+----------------------------------
+
+#### Options Final Settlement Price TaiwanOptionFinalSettlementPrice (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2001-01-01 ~ now
+- Data update time: **Monday to Friday every 3 hours**. The actual update time is based on the API data.
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanOptionFinalSettlementPrice",
+            "data_id": "TXO",
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanOptionFinalSettlementPrice",
+                data_id="TXO",
+                start_date= "2024-01-01",
+                end_date= "2024-12-31"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_option_final_settlement_price(
+            option_id_list=['TXO', 'TEO'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       | contract_month | option_type | option_id | option_name      | settlement_price | underlying_code | notional_value |
+        |---:|:-----------|:---------------|:------------|:----------|:-----------------|:-----------------|:----------------|:---------------|
+        |  0 | 2024-01-17 | 202401         | index       | TXO       | 臺指選擇權       | 17881.0          |                 | 0.0            |
+        |  1 | 2024-02-21 | 202402         | index       | TXO       | 臺指選擇權       | 18658.0          |                 | 0.0            |
+        |  2 | 2024-03-20 | 202403         | index       | TXO       | 臺指選擇權       | 20199.0          |                 | 0.0            |
+    === "Schema"
+        ```
+        {
+            date: str, # expiration date
+            contract_month: str, # contract month
+            option_type: str, # option type (index/stock)
+            option_id: str, # option code
+            option_name: str, # option name
+            settlement_price: float64, # final settlement price
+            underlying_code: str, # underlying security code
+            notional_value: float64 # notional contract value
+        }
+        ```
+
+----------------------------------

--- a/docs/tutor/TaiwanMarket/Fundamental.en.md
+++ b/docs/tutor/TaiwanMarket/Fundamental.en.md
@@ -1,0 +1,1715 @@
+
+In Taiwan stock fundamental data, we have 12 datasets, as follows:
+
+- [Income Statement TaiwanStockFinancialStatements](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockfinancialstatements)
+- [Balance Sheet TaiwanStockBalanceSheet](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockbalancesheet)
+- [Cash Flows Statement TaiwanStockCashFlowsStatement](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockcashflowsstatement)
+- [Dividend Policy Table TaiwanStockDividend](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockdividend)
+- [Ex-Dividend/Ex-Right Result Table TaiwanStockDividendResult](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockdividendresult)
+- [Monthly Revenue Table TaiwanStockMonthRevenue](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockmonthrevenue)
+- [Capital Reduction Resumption Reference Price TaiwanStockCapitalReductionReferencePrice](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockcapitalreductionreferenceprice)
+- [Taiwan Stock Market Value Table TaiwanStockMarketValue](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockmarketvalue-backersponsor)
+- [Taiwan Stock Delisting Table TaiwanStockDelisting](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockdelisting)
+- [Taiwan Stock Market Value Weight Table TaiwanStockMarketValueWeight](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockmarketvalueweight-backersponsor)
+- [Taiwan Stock Post-Split Reference Price TaiwanStockSplitPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstocksplitprice)
+- [Taiwan Stock Par Value Change Resumption Reference Price TaiwanStockParValueChange](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockparvaluechange)
+
+----------------------------------
+#### Income Statement TaiwanStockFinancialStatements
+
+- Data range: 1990-03-01 ~ now
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_financial_statement(
+            stock_id="2330",
+            start_date='2019-01-01',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockFinancialStatements",
+            "data_id": "2330",
+            "start_date": "2019-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockFinancialStatements",
+                data_id="2330",
+                start_date= "2019-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_financial_statement(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | type                               |       value | origin_name                  |
+        |---:|:-----------|-----------:|:-----------------------------------|------------:|:-----------------------------|
+        |  0 | 2019-03-31 |       2330 | CostOfGoodsSold                    | 1.28352e+11 | 營業成本                     |
+        |  1 | 2019-03-31 |       2330 | EPS                                | 2.37        | 基本每股盈餘（元）           |
+        |  2 | 2019-03-31 |       2330 | EquityAttributableToOwnersOfParent | 6.60098e+10 | 綜合損益總額歸屬於母公司業主 |
+        |  3 | 2019-03-31 |       2330 | GrossProfit                        | 9.03576e+10 | 營業毛利（毛損）淨額         |
+        |  4 | 2019-03-31 |       2330 | IncomeAfterTaxes                   | 6.13873e+10 | 本期淨利（淨損）             |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            type: str, # category
+            value: float64, # value
+            origin_name: str # original name
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_financial_statement(
+            start_date='2019-03-31',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockFinancialStatements",
+            "start_date": "2019-03-31",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data)
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockFinancialStatements",
+                start_date= "2019-03-31"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | type                               |       value | origin_name                  |
+        |---:|:-----------|-----------:|:-----------------------------------|------------:|:-----------------------------|
+        |  0 | 2019-03-31 |     000116 | EPS                                | 0.24        | 基本每股盈餘（元）           |
+        |  1 | 2019-03-31 |     000116 | EquityAttributableToOwnersOfParent | 4.65569e+08 | 綜合損益總額歸屬於母公司業主 |
+        |  2 | 2019-03-31 |     000116 | Expense                            | 8.95498e+08 | 支出及費用                   |
+        |  3 | 2019-03-31 |     000116 | Income                             | 1.07791e+09 | 收益                         |
+        |  4 | 2019-03-31 |     000116 | IncomeAfterTaxes                   | 2.74322e+08 | 本期淨利（淨損）             |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            type: str, # category
+            value: float64, # value
+            origin_name: str # original name
+        }
+        ```
+
+----------------------------------
+#### Balance Sheet TaiwanStockBalanceSheet
+
+- Data range: 2011-12-01 ~ now
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_balance_sheet(
+            stock_id="2330",
+            start_date='2019-03-31',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockBalanceSheet",
+            "data_id": "2330",
+            "start_date": "2019-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockBalanceSheet",
+                data_id="2330",
+                start_date= "2019-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_balance_sheet(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | type                                       |       value | origin_name          |
+        |---:|:-----------|-----------:|:-------------------------------------------|------------:|:---------------------|
+        |  0 | 2019-03-31 |       2330 | AccountsPayable                            | 2.71009e+10 | 應付帳款             |
+        |  1 | 2019-03-31 |       2330 | AccountsPayable_per                        | 1.24        | 應付帳款             |
+        |  2 | 2019-03-31 |       2330 | AccountsPayableToRelatedParties            | 5.60941e+08 | 應付帳款－關係人     |
+        |  3 | 2019-03-31 |       2330 | AccountsPayableToRelatedParties_per        | 0.03        | 應付帳款－關係人     |
+        |  4 | 2019-03-31 |       2330 | AccountsReceivableDuefromRelatedPartiesNet | 3.09821e+08 | 應收帳款－關係人淨額 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            type: str, # category
+            value: float64, # value
+            origin_name: str # original name
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_balance_sheet(
+            start_date='2019-03-31',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockBalanceSheet",
+            "start_date": "2019-03-31",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockBalanceSheet",
+                start_date= "2019-03-31"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | type                                           |       value | origin_name          |
+        |---:|:-----------|-----------:|:-----------------------------------------------|------------:|:---------------------|
+        |  0 | 2019-03-31 |       1101 | AccountsPayable                                | 7.84411e+09 | 應付帳款             |
+        |  1 | 2019-03-31 |       1101 | AccountsPayable_per                            | 2.15        | 應付帳款             |
+        |  2 | 2019-03-31 |       1101 | AccountsReceivableDuefromRelatedPartiesNet     | 2.64638e+08 | 應收帳款－關係人淨額 |
+        |  3 | 2019-03-31 |       1101 | AccountsReceivableDuefromRelatedPartiesNet_per | 0.07        | 應收帳款－關係人淨額 |
+        |  4 | 2019-03-31 |       1101 | AccountsReceivableNet                          | 8.3396e+09  | 應收帳款淨額         |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            type: str, # category
+            value: float64, # value
+            origin_name: str # original name
+        }
+        ```
+
+----------------------------------
+#### Cash Flows Statement TaiwanStockCashFlowsStatement
+
+- Data range: 2008-06-01 ~ now
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_cash_flows_statement(
+            stock_id="2330",
+            start_date='2019-03-31',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockCashFlowsStatement",
+            "data_id": "2330",
+            "start_date": "2019-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockCashFlowsStatement",
+                data_id="2330",
+                start_date= "2019-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_cash_flows_statement(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | type                              |        value | origin_name                      |
+        |---:|:-----------|-----------:|:----------------------------------|-------------:|:---------------------------------|
+        |  0 | 2019-03-31 |       2330 | HedgingFinancialLiabilities       | -2.27383e+08 | 除列避險之金融負債               |
+        |  1 | 2019-03-31 |       2330 | CashFlowsFromOperatingActivities  |  1.5267e+11  | 營業活動之淨現金流入（流出）     |
+        |  2 | 2019-03-31 |       2330 | CashProvidedByInvestingActivities | -6.41885e+10 | 投資活動之淨現金流入(流出)       |
+        |  3 | 2019-03-31 |       2330 | CashBalancesIncrease              |  6.78559e+10 | 本期現金及約當現金增加（減少）數 |
+        |  4 | 2019-03-31 |       2330 | NetIncomeBeforeTax                |  6.81817e+10 | 本期稅前淨利（淨損）             |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            type: str, # category
+            value: float64, # value
+            origin_name: str # original name
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_cash_flows_statement(
+            start_date='2019-03-31',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockCashFlowsStatement",
+            "start_date": "2019-03-31",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockCashFlowsStatement",
+                start_date= "2019-03-31"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | type                              |        value | origin_name                |
+        |---:|:-----------|-----------:|:----------------------------------|-------------:|:---------------------------|
+        |  0 | 2019-03-31 |       1101 | DecreaseInShortTermLoans          |  7.59053e+09 | 短期借款減少               |
+        |  1 | 2019-03-31 |       1101 | ReceivableIncrease                | -1.15069e+08 | 應收帳款(增加)減少         |
+        |  2 | 2019-03-31 |       1101 | PropertyAndPlantAndEquipment      | -1.48367e+09 | 取得不動產、廠房及設備     |
+        |  3 | 2019-03-31 |       1101 | NetIncomeBeforeTax                |  5.6035e+09  | 本期稅前淨利（淨損）       |
+        |  4 | 2019-03-31 |       1101 | CashProvidedByInvestingActivities | -4.31058e+09 | 投資活動之淨現金流入(流出) |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            type: str, # category
+            value: float64, # value
+            origin_name: str # original name
+        }
+        ```
+
+----------------------------------
+#### Dividend Policy Table TaiwanStockDividend
+
+- Data range: 2005-05-01 ~ now
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_dividend(
+            stock_id="2330",
+            start_date='2019-03-31',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDividend",
+            "data_id": "2330",
+            "start_date": "2019-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockStockDividend",
+                data_id="2330",
+                start_date= "2019-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_dividend(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | year       |   StockEarningsDistribution |   StockStatutorySurplus | StockExDividendTradingDate   |   TotalEmployeeStockDividend |   TotalEmployeeStockDividendAmount |   RatioOfEmployeeStockDividendOfTotal |   RatioOfEmployeeStockDividend |   CashEarningsDistribution |   CashStatutorySurplus | CashExDividendTradingDate   | CashDividendPaymentDate   |   TotalEmployeeCashDividend |   TotalNumberOfCashCapitalIncrease |   CashIncreaseSubscriptionRate |   CashIncreaseSubscriptionpRrice |   RemunerationOfDirectorsAndSupervisors |   ParticipateDistributionOfTotalShares | AnnouncementDate   | AnnouncementTime   |
+        |---:|:-----------|-----------:|:-----------|----------------------------:|------------------------:|:-----------------------------|-----------------------------:|-----------------------------------:|--------------------------------------:|-------------------------------:|---------------------------:|-----------------------:|:----------------------------|:--------------------------|----------------------------:|-----------------------------------:|-------------------------------:|---------------------------------:|----------------------------------------:|---------------------------------------:|:-------------------|:-------------------|
+        |  0 | 2019-06-30 |       2330 | 107年      |                           0 |                       0 |                              |                            0 |                                  0 |                                     0 |                              0 |                        8   |                      0 | 2019-06-24                  | 2019-07-18                |                           0 |                                  0 |                              0 |                                0 |                                       0 |                            2.59304e+10 | 2019-06-06         | 15:47:30           |
+        |  1 | 2019-09-25 |       2330 | 108年第1季 |                           0 |                       0 |                              |                            0 |                                  0 |                                     0 |                              0 |                        2   |                      0 | 2019-09-19                  | 2019-10-17                |                           0 |                                  0 |                              0 |                                0 |                                       0 |                            2.59304e+10 | 2019-07-09         | 18:33:02           |
+        |  2 | 2019-12-25 |       2330 | 108年第2季 |                           0 |                       0 |                              |                            0 |                                  0 |                                     0 |                              0 |                        2.5 |                      0 | 2019-12-19                  | 2020-01-16                |                           0 |                                  0 |                              0 |                                0 |                                       0 |                            2.59304e+10 | 2019-08-14         | 15:27:02           |
+        |  3 | 2020-03-25 |       2330 | 108年第3季 |                           0 |                       0 |                              |                            0 |                                  0 |                                     0 |                              0 |                        2.5 |                      0 | 2020-03-19                  | 2020-04-16                |                           0 |                                  0 |                              0 |                                0 |                                       0 |                            2.59304e+10 | 2019-11-14         | 17:01:07           |
+        |  4 | 2020-06-24 |       2330 | 108年第4季 |                           0 |                       0 |                              |                            0 |                                  0 |                                     0 |                              0 |                        2.5 |                      0 | 2020-06-18                  | 2020-07-16                |                           0 |                                  0 |                              0 |                                0 |                                       0 |                            2.59304e+10 | 2020-02-14         | 15:10:50           |
+    === "Schema"
+        ```
+        {
+            date: str, # rights distribution record date
+            stock_id: str, # stock code
+            year: str, # dividend fiscal year
+            StockEarningsDistribution: float64, # stock dividend: capitalization of earnings
+            StockStatutorySurplus: float64, # stock dividend: capitalization of statutory and capital surplus
+            StockExDividendTradingDate: str, # ex-rights trading date
+            TotalEmployeeStockDividend: float64, # employee stock dividend
+            TotalEmployeeStockDividendAmount: float64, # employee stock dividend amount
+            RatioOfEmployeeStockDividendOfTotal: float64, # ratio of employee stock dividend to total earnings dividend
+            RatioOfEmployeeStockDividend: float64, # employee stock dividend ratio
+            CashEarningsDistribution: float64, # cash dividend: capitalization of earnings
+            CashStatutorySurplus: float64, # cash dividend: capitalization of statutory and capital surplus
+            CashExDividendTradingDate: str, # ex-dividend trading date
+            CashDividendPaymentDate: str, # cash dividend payment date
+            TotalEmployeeCashDividend: float64, # total employee cash bonus
+            TotalNumberOfCashCapitalIncrease: float64, # total shares of cash capital increase
+            CashIncreaseSubscriptionRate: float64, # cash capital increase subscription ratio
+            CashIncreaseSubscriptionpRrice: float64, # cash capital increase subscription price
+            RemunerationOfDirectorsAndSupervisors: float64, # directors and supervisors remuneration
+            ParticipateDistributionOfTotalShares: float64, # total shares participating in distribution
+            AnnouncementDate: str, # announcement date
+            AnnouncementTime: str # announcement time
+        }
+        ```
+
+
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_dividend(
+            start_date='2025-10-06',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDividend",
+            "start_date": "2025-10-06",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockStockDividend",
+                start_date= "2025-10-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | year   |   StockEarningsDistribution |   StockStatutorySurplus | StockExDividendTradingDate   |   TotalEmployeeStockDividend |   TotalEmployeeStockDividendAmount |   RatioOfEmployeeStockDividendOfTotal |   RatioOfEmployeeStockDividend |   CashEarningsDistribution |   CashStatutorySurplus | CashExDividendTradingDate   | CashDividendPaymentDate   |   TotalEmployeeCashDividend |   TotalNumberOfCashCapitalIncrease |   CashIncreaseSubscriptionRate |   CashIncreaseSubscriptionpRrice |   RemunerationOfDirectorsAndSupervisors |   ParticipateDistributionOfTotalShares | AnnouncementDate   | AnnouncementTime   |
+        |---:|:-----------|-----------:|:-------|----------------------------:|------------------------:|:-----------------------------|-----------------------------:|-----------------------------------:|--------------------------------------:|-------------------------------:|---------------------------:|-----------------------:|:----------------------------|:--------------------------|----------------------------:|-----------------------------------:|-------------------------------:|---------------------------------:|----------------------------------------:|---------------------------------------:|:-------------------|:-------------------|
+        |  0 | 2025-10-06 |       2540 | 113年  |                           3 |                0.999999 | 2025-09-30                   |                            0 |                                  0 |                                     0 |                              0 |                        0.4 |                    0.6 | 2025-09-30                  | 2025-10-31                |                           0 |                              0     |                           0    |                              0   |                                       0 |                            6.7491e+08  | 2025-09-12         | 17:35:32           |
+        |  1 | 2025-10-06 |       3312 | 不適用 |                           0 |                0        | 2025-09-30                   |                            0 |                                  0 |                                     0 |                              0 |                        0   |                    0   |                             |                           |                           0 |                              2e+07 |                           9.84 |                             39.8 |                                       0 |                            1.62627e+08 | 2025-09-22         | 16:52:52           |
+    === "Schema"
+        ```
+        {
+            date: str, # rights distribution record date
+            stock_id: str, # stock code
+            year: str, # dividend fiscal year
+            StockEarningsDistribution: float64, # stock dividend: capitalization of earnings
+            StockStatutorySurplus: float64, # stock dividend: capitalization of statutory and capital surplus
+            StockExDividendTradingDate: str, # ex-rights trading date
+            TotalEmployeeStockDividend: float64, # employee stock dividend
+            TotalEmployeeStockDividendAmount: float64, # employee stock dividend amount
+            RatioOfEmployeeStockDividendOfTotal: float64, # ratio of employee stock dividend to total earnings dividend
+            RatioOfEmployeeStockDividend: float64, # employee stock dividend ratio
+            CashEarningsDistribution: float64, # cash dividend: capitalization of earnings
+            CashStatutorySurplus: float64, # cash dividend: capitalization of statutory and capital surplus
+            CashExDividendTradingDate: str, # ex-dividend trading date
+            CashDividendPaymentDate: str, # cash dividend payment date
+            TotalEmployeeCashDividend: float64, # total employee cash bonus
+            TotalNumberOfCashCapitalIncrease: float64, # total shares of cash capital increase
+            CashIncreaseSubscriptionRate: float64, # cash capital increase subscription ratio
+            CashIncreaseSubscriptionpRrice: float64, # cash capital increase subscription price
+            RemunerationOfDirectorsAndSupervisors: float64, # directors and supervisors remuneration
+            ParticipateDistributionOfTotalShares: float64, # total shares participating in distribution
+            AnnouncementDate: str, # announcement date
+            AnnouncementTime: str # announcement time
+        }
+        ```
+
+----------------------------------
+#### Ex-Dividend/Ex-Right Result Table TaiwanStockDividendResult
+
+- Data range: 2003-05-01 ~ now
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_dividend_result(
+            stock_id="2330",
+            start_date='2019-03-31',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDividendResult",
+            "data_id": "2330",
+            "start_date": "2019-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockDividendResult",
+                data_id="2330",
+                start_date= "2019-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_dividend_result(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   before_price |   after_price |   stock_and_cache_dividend | stock_or_cache_dividend   |   max_price |   min_price |   open_price |   reference_price |
+        |---:|:-----------|-----------:|---------------:|--------------:|---------------------------:|:--------------------------|------------:|------------:|-------------:|------------------:|
+        |  0 | 2019-06-24 |       2330 |          248.5 |         240.5 |                        8   | 息                        |       264.5 |       216.5 |        240.5 |             240.5 |
+        |  1 | 2019-09-19 |       2330 |          267   |         265   |                        2   | 息                        |       291.5 |       238.5 |        265   |             265   |
+        |  2 | 2019-12-19 |       2330 |          344.5 |         342   |                        2.5 | 息                        |       376   |       308   |        342   |             342   |
+        |  3 | 2020-03-19 |       2330 |          260   |         257.5 |                        2.5 | 息                        |       283   |       232   |        257.5 |             257.5 |
+        |  4 | 2020-06-18 |       2330 |          315   |         312.5 |                        2.5 | 息                        |       343.5 |       281.5 |        312.5 |             312.5 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            before_price: float32, # closing price before ex-dividend/ex-right
+            after_price: float32, # closing price after ex-dividend/ex-right
+            stock_and_cache_dividend: float32, # dividend value
+            stock_or_cache_dividend: float32, # right/dividend
+            max_price: float32, # limit-up price
+            min_price: float32, # limit-down price
+            open_price: float32, # open price
+            reference_price: float32 # reference price after dividend deduction
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_dividend_result(
+            start_date='2019-06-24',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDividendResult",
+            "start_date": "2019-06-24",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockDividendResult",
+                start_date= "2019-06-24"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    | date       | stock_id   |   before_price |   after_price |   stock_and_cache_dividend | stock_or_cache_dividend   |   max_price |   min_price |   open_price |   reference_price |
+        |---:|:-----------|:-----------|---------------:|--------------:|---------------------------:|:--------------------------|------------:|------------:|-------------:|------------------:|
+        |  0 | 2019-06-24 | 00697B     |          42.48 |         42.21 |                       0.27 | 除息                      |     9999.95 |        0.01 |        42.21 |             42.21 |
+        |  1 | 2019-06-24 | 00751B     |          46.05 |         45.46 |                       0.59 | 除息                      |     9999.95 |        0.01 |        45.46 |             45.46 |
+        |  2 | 2019-06-24 | 1707       |         220    |        213.5  |                       6.5  | 息                        |      234.5  |      192.5  |       213.5  |            213.5  |
+        |  3 | 2019-06-24 | 1711       |          17    |         16.5  |                       0.5  | 息                        |       18.15 |       14.85 |        16.5  |             16.5  |
+        |  4 | 2019-06-24 | 1906       |          13.55 |         13.05 |                       0.5  | 息                        |       14.35 |       11.75 |        13.05 |             13.05 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            before_price: float32, # closing price before ex-dividend/ex-right
+            after_price: float32, # closing price after ex-dividend/ex-right
+            stock_and_cache_dividend: float32, # dividend value
+            stock_or_cache_dividend: float32, # right/dividend
+            max_price: float32, # limit-up price
+            min_price: float32, # limit-down price
+            open_price: float32, # open price
+            reference_price: float32 # reference price after dividend deduction
+        }
+        ```
+
+----------------------------------
+#### Monthly Revenue Table TaiwanStockMonthRevenue
+
+- Data range: 2002-02-01 ~ now
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_month_revenue(
+            stock_id="2330",
+            start_date='2019-03-31',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMonthRevenue",
+            "data_id": "2330",
+            "start_date": "2019-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMonthRevenue",
+                data_id="2330",
+                start_date= "2019-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_month_revenue(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | country   |     revenue |   revenue_month |   revenue_year |
+        |---:|:-----------|-----------:|:----------|------------:|----------------:|---------------:|
+        |  0 | 2019-04-01 |       2330 | Taiwan    | 79721587000 |               3 |           2019 |
+        |  1 | 2019-05-01 |       2330 | Taiwan    | 74693615000 |               4 |           2019 |
+        |  2 | 2019-06-01 |       2330 | Taiwan    | 80436931000 |               5 |           2019 |
+        |  3 | 2019-07-01 |       2330 | Taiwan    | 85867929000 |               6 |           2019 |
+        |  4 | 2019-08-01 |       2330 | Taiwan    | 84757724000 |               7 |           2019 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            country: str, # country
+            revenue: int64, # revenue
+            revenue_month: int64, # revenue month
+            revenue_year: int64 # revenue year
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_month_revenue(
+            start_date='2019-04-01',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMonthRevenue",
+            "start_date": "2019-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMonthRevenue",
+                start_date= "2019-01-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | country   |     revenue |   revenue_month |   revenue_year |
+        |---:|:-----------|-----------:|:----------|------------:|----------------:|---------------:|
+        |  0 | 2019-05-01 |       1101 | Taiwan    | 10596314000 |               4 |           2019 |
+        |  1 | 2019-05-01 |       1102 | Taiwan    |  8434811000 |               4 |           2019 |
+        |  2 | 2019-05-01 |       1103 | Taiwan    |   160751000 |               4 |           2019 |
+        |  3 | 2019-05-01 |       1104 | Taiwan    |   418992000 |               4 |           2019 |
+        |  4 | 2019-05-01 |       1108 | Taiwan    |   323834000 |               4 |           2019 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            country: str, # country
+            revenue: int64, # revenue
+            revenue_month: int64, # revenue month
+            revenue_year: int64 # revenue year
+        }
+        ```
+----------------------------------
+#### Capital Reduction Resumption Reference Price TaiwanStockCapitalReductionReferencePrice
+
+- Data range: 2011-01-01 ~ now
+
+!!! example
+    === "Python"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockCapitalReductionReferencePrice",
+            "data_id": "2327",
+            "start_date": "2010-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+                date stock_id  ClosingPriceonTheLastTradingDay  PostReductionReferencePrice  LimitUp  LimitDown  OpeningReferencePrice  ExrightReferencePrice ReasonforCapitalReduction
+        0  2013-09-18     2327                            10.20                        10.28    10.95       9.57                   10.3                   -1.0               Cash refund
+        1  2014-10-09     2327                            22.05                        49.82    53.30      46.35                   49.8                   -1.0               Cash refund
+        2  2016-08-15     2327                            54.80                        65.96    72.50      59.40                   66.0                   -1.0               Cash refund
+        3  2017-08-18     2327                           120.50                       168.13   184.50     151.50                  168.0                   -1.0               Cash refund
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockCapitalReductionReferencePrice",
+                data_id="2327",
+                start_date= "2010-01-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+                date stock_id  ClosingPriceonTheLastTradingDay  PostReductionReferencePrice  LimitUp  LimitDown  OpeningReferencePrice  ExrightReferencePrice ReasonforCapitalReduction
+        1  2013-09-18     2327                            10.20                        10.28    10.95       9.57                   10.3                   -1.0               Cash refund
+        2  2014-10-09     2327                            22.05                        49.82    53.30      46.35                   49.8                   -1.0               Cash refund
+        3  2016-08-15     2327                            54.80                        65.96    72.50      59.40                   66.0                   -1.0               Cash refund
+        4  2017-08-18     2327                           120.50                       168.13   184.50     151.50                  168.0                   -1.0               Cash refund
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_capital_reduction_reference_price(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+
+----------------------------------
+#### Taiwan Stock Market Value Table TaiwanStockMarketValue (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2004-01-01 ~ now
+- Data update time: **Monday to Friday 23:30**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_market_value(
+            stock_id='2330',
+            start_date='2023-01-01',
+            end_date='2024-01-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMarketValue",
+            "data_id": "2330",
+            "start_date": "2023-01-01",
+            "end_date": "2024-01-01",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+            response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMarketValue",
+                data_id= "2330",
+                start_date= "2023-01-01",
+                end_date= "2024-01-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   market_value |
+        |---:|:-----------|-----------:|-----------------:|
+        |  0 | 2023-01-03 |       2330 |         1.174646e+13 |
+        |  1 | 2023-01-04 |       2330 |         1.165571e+13 |
+        |  2 | 2023-01-05 |       2330 |         1.188908e+13 |
+        |  3 | 2023-01-06 |       2330 |         1.188908e+13 |
+        |  4 | 2023-01-09 |       2330 |         1.247251e+13 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            market_value: int64 # market value
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_daily(
+            start_date='2023-01-03',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMarketValue",
+            "start_date": "2023-01-03",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMarketValue",
+                start_date= "2023-01-03"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |     market_value |
+        |---:|:-----------|-----------:|-----------------:|
+        |  0 | 2023-01-03 |       0050 |     2.561094e+11 |
+        |  1 | 2023-01-03 |       0051 |     7.967000e+08 |
+        |  2 | 2023-01-03 |       0052 |     5.644650e+09 |
+        |  3 | 2023-01-03 |       0053 |     2.611218e+08 |
+        |  4 | 2023-01-03 |       0055 |     1.625804e+09 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            market_value: int64 # market value
+        }
+        ```
+
+
+----------------------------------
+#### Taiwan Stock Delisting Table TaiwanStockDelisting
+
+- Data range: 2001-01-01 ~ now
+- Data update time: **Monday to Friday 23:30**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_delisting()
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDelisting",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockDelisting"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_delisting(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   stock_name |
+        |---:|:-----------|-----------:|-------------:|
+        |  0 | 2005-10-04 |       1204 |          津津 |
+        |  1 | 2001-11-01 |       1230 |      聯成食品 |
+        |  2 | 2005-10-04 |       1306 |      合發興業 |
+        |  3 | 2006-06-26 |       1408 |      中興紡織 |
+        |  4 | 2002-11-08 |       1431 |      新燕實業 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            stock_name: str # stock name
+        }
+        ```
+
+
+----------------------------------
+#### Taiwan Stock Market Value Weight Table TaiwanStockMarketValueWeight (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2024-10-30 ~ now
+- Data update time: **23:45 on the 1st, 2nd, 3rd, 28th, 29th, 30th, and 31st of each month**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_market_value_weight(
+            stock_id='2330',
+            start_date='2024-01-01',
+            end_date='2025-01-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMarketValueWeight",
+            "data_id": "2330",
+            "start_date": "2024-01-01",
+            "end_date": "2025-01-01",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMarketValueWeight",
+                data_id= "2330",
+                start_date= "2024-01-01",
+                end_date= "2025-01-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | rank |  stock_id  |  stock_name |  weight_per  |    date     |   type  |
+        |---:|:-----|-----------:|------------:|-------------:|------------:|--------:|
+        |  0 |   1  |    2330    |   台積電     |    36.8397   | 2024-10-30  |   twse  |
+    === "Schema"
+        ```
+        {
+            rank: int64, # rank
+            stock_id: str, # stock code
+            stock_name: str, # stock name
+            weight_per: float32, # weight percentage
+            date: str, # date
+            type: str # listed (twse) / OTC (tpex)
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_market_value_weight(
+            start_date='2024-10-30',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMarketValueWeight",
+            "start_date": "2024-10-30",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMarketValueWeight",
+                start_date= "2024-10-30"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | rank  |  stock_id  |  stock_name |  weight_per  |    date     |   type  |
+        |---:|:------|-----------:|------------:|-------------:|------------:|--------:|
+        |  0 |   43  |    1101    |   台泥       |    0.3327    | 2024-10-30  |   twse  |
+        |  0 |   63  |    1102    |   亞泥       |    0.2282    | 2024-10-30  |   twse  |
+        |  0 |   394 |    1103    |   嘉泥       |    0.0192    | 2024-10-30  |   twse  |
+        |  0 |   305 |    1104    |   環泥       |    0.0286    | 2024-10-30  |   twse  |
+        |  0 |   651 |    1108    |   幸福       |    0.0082    | 2024-10-30  |   twse  |
+    === "Schema"
+        ```
+        {
+            rank: int64, # rank
+            stock_id: str, # stock code
+            stock_name: str, # stock name
+            weight_per: float32, # weight percentage
+            date: str, # date
+            type: str # listed (twse) / OTC (tpex)
+        }
+        ```
+
+
+----------------------------------
+#### Taiwan Stock Post-Split Reference Price TaiwanStockSplitPrice
+
+- Provides Taiwan stock post-split reference prices.
+- Data update time: Monday to Friday 18:00. The actual update time is based on the API data.
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockSplitPrice",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockSplitPrice"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       | stock_id   | type   |   before_price |   after_price |   max_price |   min_price |   open_price |
+        |---:|:-----------|:-----------|:-------|---------------:|--------------:|------------:|------------:|-------------:|
+        |  0 | 2024-12-11 | 00632R     | 反分割 |           3.28 |         22.96 |       25.25 |       20.67 |        22.96 |
+        |  1 | 2025-02-19 | 00676R     | 反分割 |           2.04 |         12.23 |       13.45 |       11.01 |        12.23 |
+        |  2 | 2025-06-11 | 00663L     | 分割   |         170.15 |         24.3  |       29.16 |       19.44 |        24.3  |
+        |  3 | 2025-06-18 | 0050       | 分割   |         188.65 |         47.16 |       51.85 |       42.45 |        47.16 |
+    === "Schema"
+        ```
+        {
+            date: str, # split date
+            stock_id: str, # stock code
+            type: str, # split type
+            before_price: float, # pre-split price
+            after_price: float, # post-split price
+            max_price: float, # post-split max price
+            min_price: float, # post-split min price
+            open_price: float # post-split open price
+        }
+        ```
+
+----------------------------------
+#### Taiwan Stock Par Value Change Resumption Reference Price TaiwanStockParValueChange
+
+- Data range: 2020-01-01 ~ now
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_par_value_change(
+            start_date='2020-01-01',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockParValueChange",
+            "start_date": "2020-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockParValueChange",
+                start_date= "2020-01-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | stock_name   | before_close | after_ref_close | after_ref_max | after_ref_min | after_ref_open |
+        |---:|:-----------|-----------:|-------------:|-------------:|----------------:|-------------:|----------------:|-------------:|
+        |  0 | 2020-08-17 |       8070 | 長華         |      190       |      19        |      20.9     |      17.1      |      19      |
+        |  1 | 2021-10-18 |       6531 | 愛普         |      750       |     375        |     412.5     |     337.5      |     375      |
+        |  2 | 2022-07-13 |       6415 | 矽力-K       |     2485       |     621.25     |     683       |     560        |     621      |
+        |  3 | 2024-11-11 |       8476 | 台境         |       58.8     |      29.4      |      32.3     |      26.5      |      29.4    |
+        |  4 | 2025-06-30 |       4763 | 材料-KY      |      885       |      88.5      |      97.3     |      79.7      |      88.5    |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            stock_name: str, # stock name
+            before_close: float64, # closing price before suspension
+            after_ref_close: float64, # resumption reference price
+            after_ref_max: float64, # limit-up price
+            after_ref_min: float64, # limit-down price
+            after_ref_open: float64 # opening auction reference price
+        }
+        ```
+

--- a/docs/tutor/TaiwanMarket/Others.en.md
+++ b/docs/tutor/TaiwanMarket/Others.en.md
@@ -1,0 +1,200 @@
+
+For Taiwan stock news and other data, we have 3 datasets, as listed below:
+
+- [Related News Table TaiwanStockNews](https://finmind.github.io/en/tutor/TaiwanMarket/Others/#taiwanstocknews)
+- [Taiwan Monthly Business Indicator Table TaiwanBusinessIndicator](https://finmind.github.io/en/tutor/TaiwanMarket/Others/#taiwanbusinessindicator-backersponsor)
+- [Per-Company Industry Chain TaiwanStockIndustryChain](https://finmind.github.io/en/tutor/TaiwanMarket/Others/#taiwanstockindustrychain-backersponsor)
+
+
+#### Related News Table TaiwanStockNews
+
+(Because the data volume is large, only one day's worth of data is returned per request.)
+
+!!! example
+    === "Python"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockNews",
+            "data_id":"2330",
+            "start_date": "2020-04-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # See login section to obtain a token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockNews",
+                data_id="2330",
+                start_date= "2020-04-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        | date | stock_id             | description     | link         | source                | title |
+        |-----:|:---------------------|----------------:|:-------------:|:--------------------:|:------|
+        | 0    | 2020-04-01 00:00:00  |   2330          | &lt;a href="https://tw.news.yahoo.com/%E9%9B%B...  | https://tw.news.yahoo.com/%E9%9B%BB%E5%AD%90%E...    | Yahoo奇摩新聞  | 電子時報：台積電3奈米照走，三星衝擊大，蘋果下修5奈米訂單，NVIDIA補位 - Yahoo...
+        | 1    | 2020-04-01 00:57:33  |   2330          | &lt;a href="https://udn.com/news/story/6850/44...  | https://udn.com/news/story/6850/4458587              | udn 聯合新聞網                             | 世芯中國伺服器需求增 - udn 聯合新聞網
+        | 2    | 2020-04-01 00:58:42  |   2330          | &lt;a href="https://finance.technews.tw/2020/0...  | https://finance.technews.tw/2020/04/01/tsmc-wa...    | 科技新報 TechNews             | 台積電發展工業廢水再生技術，南科工程明年啟動 - 科技新報 TechNews
+        | 3    | 2020-04-01 00:59:38  |   2330          | &lt;a href="https://tw.news.yahoo.com/%E5%8F%B...  | https://tw.news.yahoo.com/%E5%8F%B0%E7%A9%8D%E...    | Yahoo奇摩股市     | 台積電ADR31日下跌0.03美元跌幅0.06%折台股289.17元 - Yahoo奇摩股市
+        | 4    | 2020-04-01 02:40:00  |   2330          | &lt;a href="https://fnc.ebc.net.tw/FncNews/Con...  | https://fnc.ebc.net.tw/FncNews/Content/117374        | 東森財經新聞        | 外資:半導體庫存面臨修正台積電營收成長、目標價遭雙降｜東森財經新聞 - 東森財經新聞
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            description: str, # description
+            link: str, # link
+            source: str, # source
+            title: str # title
+        }
+        ```
+
+#### Taiwan Monthly Business Indicator Table TaiwanBusinessIndicator (only available to [backer/sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 1982-01-01 ~ now
+
+!!! example
+    === "Python"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanBusinessIndicator",
+            "start_date": "2024-04-01",
+            "end_date": "2025-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # See login section to obtain a token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanBusinessIndicator",
+                start_date= "2020-04-01",
+                end_date= "2025-01-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |      |    date     |   leading  | leading_notrend   | coincident  | coincident_notrend  | lagging |  lagging_notrend |  monitoring |  monitoring_color |
+        |-----:|:------------|-----------:|:-----------------:|:-----------:|:--------------------|:--------|:-----------------|:------------|:------------------|
+        | 0    | 2024-01-01  |    92.32   |      99.85        |      90.8   |          98.21      |  91.82  |         99.31    |      27     |         G         |
+        | 1    | 2024-02-01  |    92.71   |      100.35       |      91.45  |          98.99      |  91.68  |         99.25    |      29     |         G         |
+        | 2    | 2024-03-01  |    93.19   |      100.95       |      92.28  |          99.97      |  91.6   |         99.23    |      31     |         G         |
+        | 3    | 2024-04-01  |    93.75   |      101.63       |      93.23  |          101.07     |  91.52  |         99.22    |      35     |         YR        |
+        | 4    | 2024-05-01  |    94.29   |      102.28       |      94.21  |          102.19     |  91.41  |         99.16    |      36     |         YR        |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            leading: float32, # leading composite indicator
+            leading_notrend: float32, # leading indicator excluding trend
+            coincident: float32, # coincident composite indicator
+            coincident_notrend: float32, # coincident indicator excluding trend
+            lagging: float32, # lagging composite indicator
+            lagging_notrend: float32, # lagging indicator excluding trend
+            monitoring: float32, # business indicator composite score
+            monitoring_color: str # business indicator signal
+        }
+        ```
+
+#### Per-Company Industry Chain TaiwanStockIndustryChain (only available to [backer/sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_industry_chain()
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockIndustryChain",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # See login section to obtain a token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockIndustryChain"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |      | stock_id  |   industry  |      sub_industry        |    date    |
+        |-----:|:----------|-----------:|:-------------------------:|:------------:|
+        | 0    |    1218   |    食品     | 冷凍、罐頭、脫水、醃漬食品 |   2025-03-30  |
+        | 1    |    1218   |    食品     |          加工食品        |   2025-03-30  |
+        | 2    |    1219   |    食品     |          加工食品        |   2025-03-30  |
+        | 3    |    1219   |    雲端運算 |          系統整合        |   2025-03-30 |
+        | 4    |    1236   |    食品     |          乳製品          |   2025-03-30 |
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock code
+            industry: str, # industry
+            sub_industry: str, # sub-industry
+            date: str # update date
+        }
+        ```

--- a/docs/tutor/TaiwanMarket/RealTime.en.md
+++ b/docs/tutor/TaiwanMarket/RealTime.en.md
@@ -1,0 +1,338 @@
+For Taiwan stock real-time data, we have 4 datasets, as listed below:
+
+
+- [Taiwan Stock Real-Time Information taiwan_stock_tick_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan_stock_tick_snapshot-sponsor)
+- [Futures and Options Real-Time Quote Overview TaiwanFutOptTickInfo](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwanfutopttickinfo)
+- [Taiwan Futures Real-Time Information taiwan_futures_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan_futures_snapshot-sponsor)
+- [Taiwan Options Real-Time Information taiwan_options_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan_options_snapshot-sponsor)
+
+
+----------------------------------
+#### Taiwan Stock Real-Time Information taiwan_stock_tick_snapshot (only available to [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+(updated approximately every 10 seconds)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_tick_snapshot(stock_id="2330")
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        url = "https://api.finmindtrade.com/api/v4/taiwan_stock_tick_snapshot"
+        parameter = {
+            "data_id": "2330",
+            # "data_id": ["2330", "2317"], # fetch multiple at once
+            # "data_id": "", # fetch all at once
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # See login section to obtain a token
+        url = "https://api.finmindtrade.com/api/v4/taiwan_stock_tick_snapshot"
+        response = httr::GET(
+        url = url,
+        query = list(
+            data_id="2330",
+            # data_id=c("2330", "2317"), # fetch multiple at once
+            # data_id="", # fetch all at once
+            token = "" # See login section to obtain a token
+        ),
+        add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   amount |   average_price |   buy_price |   buy_volume |   change_price |   change_rate |   close |   high |   low |   open |   sell_price |   sell_volume |   total_amount |   total_volume |   volume |   volume_ratio |   yesterday_volume | date                       |   stock_id |   TickType |
+        |---:|---------:|----------------:|------------:|-------------:|---------------:|--------------:|--------:|-------:|------:|-------:|-------------:|--------------:|---------------:|---------------:|---------:|---------------:|-------------------:|:---------------------------|-----------:|-----------:|
+        |  0 |   610000 |          611.42 |         609 |          208 |              3 |          0.49 |     610 |    614 |   608 |    614 |          610 |           821 |     5578566000 |           9124 |        1 |           0.49 |              18606 | 2021-12-08 10:31:23.098000 |       2330 |          1 |
+    === "Schema"
+        ```
+        {
+            amount: int32, # transaction amount
+            average_price: float64, # average transaction price
+            buy_price: float64, # bid price
+            buy_volume: int64, # bid volume
+            change_price: str, # price change
+            change_rate: float64, # percent change
+            close: float64, # latest transaction price
+            high: float64, # high
+            low: float64, # low
+            open: float64, # open
+            sell_price: float64, # ask price
+            sell_volume: int64, # ask volume
+            total_amount: int32, # cumulative transaction amount
+            total_volume: int64, # cumulative volume
+            volume: int64, # volume
+            volume_ratio: float64, # ratio of today's volume to yesterday's
+            yesterday_volume: int64, # yesterday's volume
+            date: str, # transaction time
+            stock_id: str, # stock code
+            TickType: str # tick type (0: undetermined, 1: sell-side, 2: buy-side)
+        }
+        ```
+
+----------------------------------
+#### Futures and Options Real-Time Quote Overview TaiwanFutOptTickInfo
+Currently supports real-time quotes for TAIEX futures and TAIEX options.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futopt_tick_info()
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanFutOptTickInfo",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # See login section to obtain a token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanFutOptTickInfo"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    | code       | callput   | date    | name           | listing_date   |   expire_price | update_date   |
+        |---:|:-----------|:----------|:--------|:---------------|:---------------|---------------:|:--------------|
+        |  0 | CAO00675R3 | 賣權      | 2023/06 | 南亞股票選擇權 | 2023-04-20     |           67.5 | 2023-06-05    |
+        |  1 | CAO00850R3 | 賣權      | 2023/06 | 南亞股票選擇權 | 2023-01-31     |           85   | 2023-06-05    |
+        |  2 | CBO00360R3 | 賣權      | 2023/06 | 中鋼股票選擇權 | 2023-01-31     |           36   | 2023-06-05    |
+        |  3 | CCO00430R3 | 賣權      | 2023/06 | 聯電股票選擇權 | 2023-04-20     |           43   | 2023-06-05    |
+        |  4 | CCO00440R3 | 賣權      | 2023/06 | 聯電股票選擇權 | 2023-01-31     |           44   | 2023-06-05    |
+    === "Schema"
+        ```
+        {
+            code: str, # code
+            callput: str, # call/put
+            date: str, # date
+            name: str, # name
+            listing_date: str, # listing date
+            expire_price: float64, # strike price
+            update_date: str # update date
+        }
+        ```
+
+----------------------------------
+#### Taiwan Futures Real-Time Information taiwan_futures_snapshot (only available to [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+(updated approximately every 30 seconds)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_futures_snapshot(futures_id="TXF")
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        url = "https://api.finmindtrade.com/api/v4/taiwan_futures_snapshot"
+        parameter = {
+            "data_id": "TXF", # TXF, TMF, CDF
+            # "data_id": "", # fetch all at once
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        print(df.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = "https://api.finmindtrade.com/api/v4/taiwan_futures_snapshot"
+        token = "" # See login section to obtain a token
+        response = httr::GET(
+            url = url,
+            query = list(
+                data_id="TXF" # TXF, TMF, CDF
+                # data_id="" # fetch all at once
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   open |   high |   low |   close |   change_price |   change_rate |   average_price |   volume |   total_volume |   amount |   total_amount |   yesterday_volume |   buy_price |   buy_volume |   sell_price |   sell_volume |   volume_ratio | date                    | futures_id   |   TickType |
+        |---:|-------:|-------:|------:|--------:|---------------:|--------------:|----------------:|---------:|---------------:|---------:|---------------:|-------------------:|------------:|-------------:|-------------:|--------------:|---------------:|:------------------------|:-------------|-----------:|
+        |  0 |  16720 |  16800 | 16714 |   16762 |             51 |          0.31 |         16757.2 |        1 |          52822 |    16762 |      885151394 |              46576 |       16760 |           61 |        16765 |             8 |        1.13 | 2023-06-03 04:59:59.243 | TXFR1        |          2 |
+        |  1 |  16720 |  16800 | 16714 |   16762 |             51 |          0.31 |         16757.2 |        1 |          52822 |    16762 |      885151394 |              46576 |       16760 |           61 |        16765 |             8 |        1.13 | 2023-06-03 04:59:59.243 | TXFF3        |          2 |
+        |  2 |  16290 |  16291 | 16290 |   16291 |             68 |          0.42 |         16290.5 |        1 |              2 |    16291 |          32581 |                  3 |       16266 |            2 |        16500 |             2 |        0.67 | 2023-06-02 23:01:10.244 | TXFC4        |          1 |
+        |  3 |  16409 |  16468 | 16400 |   16449 |             64 |          0.39 |         16431.9 |        1 |            110 |    16449 |        1807505 |                 90 |       16424 |            1 |        16450 |             1 |        1.22 | 2023-06-03 03:00:34.248 | TXFH3        |          1 |
+        |  4 |  16300 |  16373 | 16300 |   16335 |             56 |          0.34 |         16340.8 |        1 |             10 |    16335 |         163408 |                  8 |       16315 |            1 |        16355 |             1 |        1.25 | 2023-06-03 03:36:00.561 | TXFL3        |          1 |
+    === "Schema"
+        ```
+        {
+            open: float64, # open
+            high: float64, # high
+            low: float64, # low
+            close: float64, # latest transaction price
+            change_price: float64, # price change
+            change_rate: float64, # percent change
+            average_price: float64, # average transaction price
+            volume: int64, # volume
+            total_volume: int64, # cumulative volume
+            amount: str, # transaction amount
+            total_amount: str, # cumulative transaction amount
+            yesterday_volume: int64, # yesterday's volume
+            buy_price: float64, # bid price
+            buy_volume: int64, # bid volume
+            sell_price: float64, # ask price
+            sell_volume: int64, # ask volume
+            volume_ratio: float64, # ratio of today's volume to yesterday's
+            date: str, # transaction time
+            futures_id: str, # futures code
+            TickType: str # tick type (0: undetermined, 1: sell-side, 2: buy-side)
+        }
+        ```
+
+----------------------------------
+#### Taiwan Options Real-Time Information taiwan_options_snapshot (only available to [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+(updated approximately every 30 seconds)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+        # Currently only TAIEX options are supported: TXO, TX1, TX2, TX3, TX4
+        df = api.taiwan_options_snapshot(options_id="TXO")
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        token = "" # See login section to obtain a token
+        headers = {"Authorization": f"Bearer {token}"}
+        url = "https://api.finmindtrade.com/api/v4/taiwan_options_snapshot"
+        parameter = {
+            "data_id": "TXO", # TXO, TX1, TX2, TX3, TX4, TX5
+            # "data_id": "", # fetch all at once
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        df = pd.DataFrame(data["data"])
+        print(df.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # See login section to obtain a token
+        url = "https://api.finmindtrade.com/api/v4/taiwan_options_snapshot"
+        response = httr::GET(
+            url = url,
+            query = list(
+                data_id="TXO" # TXO, TX1, TX2, TX3, TX4, TX5
+                # data_id="" # fetch all at once
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   open |   high |   low |   close |   change_price |   change_rate |   average_price |   volume |   total_volume |   amount |   total_amount |   yesterday_volume |   buy_price |   buy_volume |   sell_price |   sell_volume |   volume_ratio | date                    | options_id   |   TickType |
+        |---:|-------:|-------:|------:|--------:|---------------:|--------------:|----------------:|---------:|---------------:|---------:|---------------:|-------------------:|------------:|-------------:|-------------:|--------------:|---------------:|:------------------------|:-------------|-----------:|
+        |  0 |     46 |     46 |  45.5 |    46   |          -12   |        -20.69 |           45.75 |       17 |             40 |      782 |           1830 |                  2 |         0.6 |            5 |            0 |             0 |        20    | 2023-06-02 13:07:35.299 | TXO14300T3   |          1 |
+        |  1 |     60 |     65 |  46.5 |    46.5 |          -17.5 |        -27.34 |           58.76 |        1 |            939 |       46 |          55172 |                936 |        48.5 |            2 |           65 |             3 |        1    | 2023-06-03 02:07:52.807 | TXO15400S3   |          2 |
+        |  2 |    905 |    910 | 875   |   875   |          -45   |         -4.89 |          891.25 |        1 |              4 |      875 |           3565 |                  2 |         1.1 |            6 |            0 |             0 |        2    | 2023-06-02 20:06:14.720 | TXO17000U3   |          2 |
+        |  3 |    695 |    695 | 695   |   695   |           25   |          3.73 |          695    |        1 |              1 |      695 |            695 |                 13 |         6.3 |            1 |         1030 |             2 |        0.08 | 2023-06-02 15:29:16.150 | TXO16400L3   |          1 |
+        |  4 |      0 |      0 |   0   |     0   |            0   |          0    |            0    |        0 |              0 |        0 |              0 |                  0 |         1.1 |            3 |            0 |             0 |        0    | 2023-06-04 08:30:00.000 | TXO15000H3   |          0 |
+    === "Schema"
+        ```
+        {
+            open: float64, # open
+            high: float64, # high
+            low: float64, # low
+            close: float64, # latest transaction price
+            change_price: float64, # price change
+            change_rate: float64, # percent change
+            average_price: float64, # average transaction price
+            volume: int64, # volume
+            total_volume: int64, # cumulative volume
+            amount: str, # transaction amount
+            total_amount: str, # cumulative transaction amount
+            yesterday_volume: int64, # yesterday's volume
+            buy_price: float64, # bid price
+            buy_volume: int64, # bid volume
+            sell_price: float64, # ask price
+            sell_volume: int64, # ask volume
+            volume_ratio: float64, # ratio of today's volume to yesterday's
+            date: str, # transaction time
+            options_id: str, # options code
+            TickType: str # tick type (0: undetermined, 1: sell-side, 2: buy-side)
+        }
+        ```

--- a/docs/tutor/TaiwanMarket/Technical.en.md
+++ b/docs/tutor/TaiwanMarket/Technical.en.md
@@ -1,0 +1,2436 @@
+In Taiwan stock technical data, we have 20 datasets, as follows:
+
+- [Taiwan Stock Overview TaiwanStockInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfo)
+- [Taiwan Stock Overview (with Warrants) TaiwanStockInfoWithWarrant](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrant)
+- [Taiwan Warrant Underlying Reference Table TaiwanStockInfoWithWarrantSummary](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrantsummary-sponsor)
+- [Taiwan Stock Trading Date TaiwanStockTradingDate](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstocktradingdate)
+- [Taiwan Stock Price Table TaiwanStockPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockprice)
+- [Taiwan Stock Weekly K Table TaiwanStockWeekPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#k-taiwanstockweekprice-backersponsor)
+- [Taiwan Stock Monthly K Table TaiwanStockMonthPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#k-taiwanstockmonthprice-backersponsor)
+- [Taiwan Adjusted Stock Price Table TaiwanStockPriceAdj](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockpriceadj-backersponsor)
+- [Taiwan Stock Historical Tick Data Table TaiwanStockPriceTick](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockpricetick-backersponsor)
+- [Taiwan Individual Stock PER, PBR Table TaiwanStockPER](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#perpbr-taiwanstockper)
+- [Order and Trade Statistics Every 5 Seconds TaiwanStockStatisticsOfOrderBookAndTrade](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#5-taiwanstockstatisticsoforderbookandtrade)
+- [Taiwan Weighted Index TaiwanVariousIndicators5Seconds](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanvariousindicators5seconds)
+- [Day Trading Targets and Volume/Value TaiwanStockDayTrading](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockdaytrading)
+- [Weighted/OTC Total Return Index TaiwanStockTotalReturnIndex](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstocktotalreturnindex)
+- [Taiwan Individual Stock 10-Year Line Table TaiwanStock10Year](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstock10year-backersponsor)
+- [Taiwan Stock Minute K Table TaiwanStockKBar](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#k-taiwanstockkbar-sponsor)
+- [Index Statistics Every 5 Seconds TaiwanStockEvery5SecondsIndex](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#5-taiwanstockevery5secondsindex-backersponsor)
+- [Taiwan Stock Suspension Announcement TaiwanStockSuspended](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstocksuspended-backersponsor)
+- [Day Trading Sell-First-Then-Buy Suspension Notice TaiwanStockDayTradingSuspension](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockdaytradingsuspension-backersponsor)
+- [Daily Price Limit TaiwanStockPriceLimit](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockpricelimit-backersponsor)
+
+
+----------------------------------
+#### Taiwan Stock Overview TaiwanStockInfo
+
+- This table mainly lists all Taiwan listed (TWSE), OTC (TPEx), and Emerging stocks, including stock names, codes, and industry categories!
+- Data update time: **1:30 daily**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_info()
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockInfo",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset = "TaiwanStockInfo"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    | industry_category   |   stock_id | stock_name   | type   | date       |
+        |---:|:--------------------|-----------:|:-------------|:-------|:-----------|
+        |  0 | ETF                 |       0050 | 元大台灣50   | twse   | 2021-10-05 |
+        |  1 | ETF                 |       0051 | 元大中型100  | twse   | 2021-10-05 |
+        |  2 | ETF                 |       0052 | 富邦科技     | twse   | 2021-10-05 |
+        |  3 | ETF                 |       0053 | 元大電子     | twse   | 2021-10-05 |
+        |  4 | ETF                 |       0054 | 元大台商50   | twse   | 2021-10-05 |
+    === "Schema"
+        ```
+        {
+            industry_category: str, # industry category
+            stock_id: str, # stock code
+            stock_name: str, # stock name
+            type: str, # market type
+            date: str # update date
+        }
+        ```
+
+
+----------------------------------
+#### Taiwan Stock Overview (with Warrants) TaiwanStockInfoWithWarrant
+
+- This table mainly lists all Taiwan listed (TWSE), OTC (TPEx), and Emerging stocks and warrants, including names, codes, and industry categories!
+- Total record count exceeds 50,000.
+- Data update time: **1:30 daily**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_info_with_warrant()
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockInfoWithWarrant",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset = "TaiwanStockInfoWithWarrant"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    | industry_category   |   stock_id | stock_name   | type   | date       |
+        |---:|:--------------------|-----------:|:-------------|:-------|:-----------|
+        |  0 | ETF                 |       0050 | 元大台灣50   | twse   | 2021-10-05 |
+        |  1 | ETF                 |       0051 | 元大中型100  | twse   | 2021-10-05 |
+        |  2 | ETF                 |       0052 | 富邦科技     | twse   | 2021-10-05 |
+        |  3 | ETF                 |       0053 | 元大電子     | twse   | 2021-10-05 |
+        |  4 | ETF                 |       0054 | 元大台商50   | twse   | 2021-10-05 |
+    === "Schema"
+        ```
+        {
+            industry_category: str, # industry category
+            stock_id: str, # stock code
+            stock_name: str, # stock name
+            type: str, # market type
+            date: str # update date
+        }
+        ```
+
+----------------------------------
+#### Taiwan Warrant Underlying Reference Table TaiwanStockInfoWithWarrantSummary (available only to [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Provides the warrant underlying reference table. (Since it includes warrant data, the data volume is large and takes about a minute.)
+- Data update time: **1:30 daily**. The actual update time is based on the API data.
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockInfoWithWarrantSummary",
+            "data_id": "2330",# optional parameter
+            "start_date": "2020-04-06",# optional parameter
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset = "TaiwanStockInfoWithWarrantSummary",
+                data_id = "2330",# optional parameter
+                start_date = "2020-04-06"# optional parameter
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    |   stock_id | date       |   close |   target_stock_id |   target_close | type   | fulfillment_method   | end_date   | fulfillment_start_date   | fulfillment_end_date   |   exercise_ratio |   fulfillment_price |
+        |---:|-----------:|:-----------|--------:|------------------:|---------------:|:-------|:---------------------|:-----------|:-------------------------|:-----------------------|-----------------:|--------------------:|
+        |  0 |     052018 | 2023-07-18 |       0 |              2330 |              0 | 認購   | 美式                 | 2025-07-15 | 2023-07-18               | 2025-07-17             |             0.1  |                   0 |
+        |  1 |     052405 | 2023-07-21 |       0 |              2330 |              0 | 認購   | 美式                 | 2025-07-17 | 2023-07-21               | 2025-07-21             |             0.01 |                   0 |
+        |  2 |     057397 | 2023-09-04 |       0 |              2330 |              0 | 認購   | 美式                 | 2025-09-01 | 2023-09-04               | 2025-09-03             |             0.03 |                   0 |
+        |  3 |     057607 | 2023-09-06 |       0 |              2330 |              0 | 認購   | 美式                 | 2025-09-03 | 2023-09-06               | 2025-09-05             |             0.06 |                   0 |
+        |  4 |     060985 | 2023-10-03 |       0 |              2330 |              0 | 認購   | 美式                 | 2025-09-30 | 2023-10-03               | 2025-10-02             |             0.03 |                   0 |
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock code
+            date: str, # listing date
+            close: float, # closing price
+            target_stock_id: str, # underlying stock code
+            target_close: float, # underlying closing price
+            type: str, # warrant type
+            fulfillment_method: str, # exercise method
+            end_date: str, # last trading date
+            fulfillment_start_date: str, # exercise start date
+            fulfillment_end_date: str, # exercise end date
+            exercise_ratio: float, # exercise ratio
+            fulfillment_price: float # exercise price
+        }
+        ```
+
+----------------------------------
+#### Taiwan Stock Trading Date TaiwanStockTradingDate
+
+- Provides Taiwan stock trading dates.
+- Data update time: Monday to Friday 18:00. The actual update time is based on the API data.
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockTradingDate",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset = "TaiwanStockTradingDate"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    | date       |
+        |---:|:-----------|
+        |  0 | 2005-01-03 |
+        |  1 | 2005-01-04 |
+        |  2 | 2005-01-05 |
+        |  3 | 2005-01-06 |
+        |  4 | 2005-01-07 |
+    === "Schema"
+        ```
+        {
+            date: str # trading date
+        }
+        ```
+
+----------------------------------
+#### Daily Stock Price Information TaiwanStockPrice
+
+- Provides daily trading information for Taiwan listed (TWSE), OTC (TPEx), and Emerging stocks!
+- Data range: 1994-10-01 ~ now
+- Data update time: **Monday to Friday 17:30**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_daily(
+            stock_id='2330',
+            start_date='2020-04-02',
+            end_date='2020-04-12'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPrice",
+            "data_id": "2330",
+            "start_date": "2020-04-02",
+            "end_date": "2020-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPrice",
+                data_id= "2330",
+                start_date= "2020-04-02",
+                end_date= "2020-04-08"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_daily(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   Trading_Volume |   Trading_money |   open |   max |   min |   close |   spread |   Trading_turnover |
+        |---:|:-----------|-----------:|-----------------:|----------------:|-------:|------:|------:|--------:|---------:|-------------------:|
+        |  0 | 2020-04-06 |       2330 |         59712754 |     16324198154 |  273   | 275.5 | 270   |   275.5 |      4   |              19971 |
+        |  1 | 2020-04-07 |       2330 |         48887346 |     13817936851 |  283.5 | 284   | 280.5 |   283   |      7.5 |              24281 |
+        |  2 | 2020-04-08 |       2330 |         38698826 |     11016972354 |  285   | 285.5 | 283   |   285   |      2   |              19126 |
+        |  3 | 2020-04-09 |       2330 |         29276430 |      8346209654 |  287.5 | 288   | 282.5 |   283   |     -2   |              15271 |
+        |  4 | 2020-04-10 |       2330 |         28206858 |      7894277586 |  280   | 282   | 279   |   279.5 |     -3.5 |              15833 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            Trading_Volume: int64, # trading volume
+            Trading_money: int64, # trading amount
+            open: float64, # open price
+            max: float64, # max price
+            min: float64, # min price
+            close: float64, # close price
+            spread: float64, # price change
+            Trading_turnover: float32 # number of trades
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_daily(
+            start_date='2020-04-06',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPrice",
+            "start_date": "2020-04-06",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPrice",
+                start_date= "2020-04-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   Trading_Volume |   Trading_money |   open |   max |   min |   close |   spread |   Trading_turnover |
+        |---:|:-----------|-----------:|-----------------:|----------------:|-------:|------:|------:|--------:|---------:|-------------------:|
+        |  0 | 2020-04-06 |       0050 |         12207626 |       935731083 |  76.95 | 77.1  | 75.75 |   77.05 |     1.15 |               5824 |
+        |  1 | 2020-04-06 |       0051 |            33000 |          953030 |  29.05 | 29.05 | 28.74 |   29.05 |     0.38 |                 21 |
+        |  2 | 2020-04-06 |       0052 |           178700 |        10660088 |  59.4  | 60.05 | 58.75 |   60    |     1.25 |                 56 |
+        |  3 | 2020-04-06 |       0053 |            17000 |          589750 |  34.66 | 35    | 34.48 |   34.84 |     0.18 |                 17 |
+        |  4 | 2020-04-06 |       0054 |            10000 |          200040 |  19.87 | 20.03 | 19.87 |   20.03 |     0    |                  4 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            Trading_Volume: int64, # trading volume
+            Trading_money: int64, # trading amount
+            open: float64, # open price
+            max: float64, # max price
+            min: float64, # min price
+            close: float64, # close price
+            spread: float64, # price change
+            Trading_turnover: int64 # number of trades
+        }
+        ```
+
+
+----------------------------------
+
+#### Taiwan Stock Weekly K Table TaiwanStockWeekPrice (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Provides daily trading information for Taiwan listed (TWSE), OTC (TPEx), and Emerging stocks!
+- Data range: 2000-01-01 ~ now
+- Data update time: **Monday to Friday 17:30**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_weekly(
+            stock_id='2330',
+            start_date='2020-04-02',
+            end_date='2020-04-12'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockWeekPrice",
+            "data_id": "2330",
+            "start_date": "2020-04-02",
+            "end_date": "2020-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockWeekPrice",
+                data_id= "2330",
+                start_date= "2020-04-02",
+                end_date= "2020-04-08"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_weekly(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    |  stock_id  |  yweek  | max | min | trading_volume | trading_money | trading_turnover |    date    |  close  |   open |   spread |
+        |---:|:-----------|:--------|-----|----:|---------------:|--------------:|-----------------:|-----------:|--------:|-------:|---------:|
+        |  0 |    2330    | 2020W15 | 288 | 270 |    409564428   |  114799189198 |      188964      | 2020-04-06 |  279.5  |   273  |      8   |
+
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock code
+            yweek: str, # weekly date
+            max: float64, # max price
+            min: float64, # min price
+            trading_volume: int64, # trading volume
+            trading_money: int64, # trading amount
+            trading_turnover: float32, # number of trades
+            date: str, # date
+            close: float64, # close price
+            open: float64, # open price
+            spread: float64 # price change
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockWeekPrice",
+            "start_date": "2020-04-06",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockWeekPrice",
+                start_date= "2020-04-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |  stock_id  |  yweek  | max | min | trading_volume | trading_money | trading_turnover |    date    |  close  |   open |   spread |
+        |---:|:-----------|:--------|-----|----:|---------------:|--------------:|-----------------:|-----------:|--------:|-------:|---------:|
+        |  0 |    2330    | 2020W15 | 288 | 270 |    409564428   |  114799189198 |      188964      | 2020-04-06 |  279.5  |   273  |      8   |
+
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock code
+            yweek: str, # weekly date
+            max: float64, # max price
+            min: float64, # min price
+            trading_volume: int64, # trading volume
+            trading_money: int64, # trading amount
+            trading_turnover: float32, # number of trades
+            date: str, # date
+            close: float64, # close price
+            open: float64, # open price
+            spread: float64 # price change
+        }
+        ```
+
+
+#### Taiwan Stock Monthly K Table TaiwanStockMonthPrice (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Provides daily trading information for Taiwan listed (TWSE), OTC (TPEx), and Emerging stocks!
+- Data range: 2000-01-01 ~ now
+- Data update time: **Monday to Friday 17:30**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_monthly(
+            stock_id='2330',
+            start_date='2020-04-02',
+            end_date='2020-04-12'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMonthPrice",
+            "data_id": "2330",
+            "start_date": "2020-04-02",
+            "end_date": "2020-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMonthPrice",
+                data_id= "2330",
+                start_date= "2020-04-02",
+                end_date= "2020-05-08"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_monthly(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    |  stock_id  |  ymonth  |  max  |  min  | trading_volume | trading_money | trading_turnover |    date    |  close  |   open   |  spread   |
+        |---:|:-----------|:---------|-------|------:|---------------:|--------------:|-----------------:|-----------:|--------:|---------:|----------:|
+        |  0 |    2330    | 2020M05  | 301.5 | 288.5 |   1744651784   |  513799591970 |      788158      | 2020-05-01 |   292   |   294.5  |   -12.5   |
+
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock code
+            ymonth: str, # monthly date
+            max: float64, # max price
+            min: float64, # min price
+            trading_volume: int64, # trading volume
+            trading_money: int64, # trading amount
+            trading_turnover: float32, # number of trades
+            date: str, # date
+            close: float64, # close price
+            open: float64, # open price
+            spread: float64 # price change
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockMonthPrice",
+            "start_date": "2020-04-06",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockMonthPrice",
+                start_date= "2020-04-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |  stock_id  |  ymonth  |  max  |  min  | trading_volume | trading_money | trading_turnover |    date    |  close  |   open   |  spread   |
+        |---:|:-----------|:---------|-------|------:|---------------:|--------------:|-----------------:|-----------:|--------:|---------:|----------:|
+        |  0 |    2330    | 2020M05  | 301.5 | 288.5 |   1744651784   |  513799591970 |      788158      | 2020-05-01 |   292   |   294.5  |   -12.5   |
+
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock code
+            ymonth: str, # monthly date
+            max: float64, # max price
+            min: float64, # min price
+            trading_volume: int64, # trading volume
+            trading_money: int64, # trading amount
+            trading_turnover: float32, # number of trades
+            date: str, # date
+            close: float64, # close price
+            open: float64, # open price
+            spread: float64 # price change
+        }
+        ```
+
+
+#### Taiwan Adjusted Stock Price Table TaiwanStockPriceAdj (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 1994-10-01 ~ now
+- Data update time: **Monday to Friday 17:30**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_daily_adj(
+            stock_id='2330',
+            start_date='2020-04-02',
+            end_date='2020-04-12'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPriceAdj",
+            "data_id": "2330",
+            "start_date": "2020-04-02",
+            "end_date": "2020-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPriceAdj",
+                data_id= "2330",
+                start_date= "2020-04-02",
+                end_date= "2020-04-08"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_daily_adj(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   Trading_Volume |   Trading_money |   open |   max |   min |   close |   spread |   Trading_turnover |
+        |---:|:-----------|-----------:|-----------------:|----------------:|-------:|------:|------:|--------:|---------:|-------------------:|
+        |  0 | 2020-04-06 |       2330 |         59712754 |     16324198154 |  273   | 275.5 | 270   |   275.5 |      4   |              19971 |
+        |  1 | 2020-04-07 |       2330 |         48887346 |     13817936851 |  283.5 | 284   | 280.5 |   283   |      7.5 |              24281 |
+        |  2 | 2020-04-08 |       2330 |         38698826 |     11016972354 |  285   | 285.5 | 283   |   285   |      2   |              19126 |
+        |  3 | 2020-04-09 |       2330 |         29276430 |      8346209654 |  287.5 | 288   | 282.5 |   283   |     -2   |              15271 |
+        |  4 | 2020-04-10 |       2330 |         28206858 |      7894277586 |  280   | 282   | 279   |   279.5 |     -3.5 |              15833 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            Trading_Volume: int64, # trading volume
+            Trading_money: int64, # trading amount
+            open: float64, # open price
+            max: float64, # max price
+            min: float64, # min price
+            close: float64, # close price
+            spread: float64, # price change
+            Trading_turnover: float32 # number of trades
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPriceAdj",
+            "start_date": "2020-04-06",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPriceAdj",
+                start_date= "2020-04-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   Trading_Volume |   Trading_money |   open |   max |   min |   close |   spread |   Trading_turnover |
+        |---:|:-----------|-----------:|-----------------:|----------------:|-------:|------:|------:|--------:|---------:|-------------------:|
+        |  0 | 2020-04-06 |       0050 |         12207626 |       935731083 |  76.95 | 77.1  | 75.75 |   77.05 |     1.15 |               5824 |
+        |  1 | 2020-04-06 |       0051 |            33000 |          953030 |  29.05 | 29.05 | 28.74 |   29.05 |     0.38 |                 21 |
+        |  2 | 2020-04-06 |       0052 |           178700 |        10660088 |  59.4  | 60.05 | 58.75 |   60    |     1.25 |                 56 |
+        |  3 | 2020-04-06 |       0053 |            17000 |          589750 |  34.66 | 35    | 34.48 |   34.84 |     0.18 |                 17 |
+        |  4 | 2020-04-06 |       0054 |            10000 |          200040 |  19.87 | 20.03 | 19.87 |   20.03 |     0    |                  4 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            Trading_Volume: int64, # trading volume
+            Trading_money: int64, # trading amount
+            open: float64, # open price
+            max: float64, # max price
+            min: float64, # min price
+            close: float64, # close price
+            spread: float64, # price change
+            Trading_turnover: float32 # number of trades
+        }
+        ```
+
+
+----------------------------------
+#### Taiwan Stock Historical Tick Data Table TaiwanStockPriceTick (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+(Due to the large data volume, each request only provides one stock's data for one day.)
+
+- Data range: 2019-01-01 ~ now.
+- Providing the dataset, stock_id, and start_date parameters returns data for that day.
+- Data update time: **Monday to Friday 15:30**. The actual update time is based on the API data.
+- Some data is missing on this date: 2019-02-20.
+- Enabling Async significantly reduces the data update time. In a Colab test, downloading 2,236 stocks took only 3 minutes 40 seconds.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_tick(
+            stock_id='2330',
+            date='2020-01-02'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import io
+        import requests
+        import pandas as pd
+
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPriceTick",
+            "data_id": "2330",
+            "start_date": "2020-01-02",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        token = ""
+
+        data_loader = DataLoader()
+        data_loader.login_by_token(token)
+
+        date = '2025-12-08'
+        start = datetime.datetime.now()
+        df = data_loader.taiwan_stock_tick(
+            date=date,
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        # 00:03:41
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPriceTick",
+                data_id= "2330",
+                start_date= "2020-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = do.call('cbind',data$data) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   deal_price |   volume | Time         |   TickType |
+        |---:|:-----------|-----------:|-------------:|---------:|:-------------|-----------:|
+        |  0 | 2020-01-02 |       2330 |        332.5 |      520 | 09:00:00.000 |          0 |
+        |  1 | 2020-01-02 |       2330 |        332.5 |      520 | 09:00:00.646 |          0 |
+        |  2 | 2020-01-02 |       2330 |        333   |       45 | 09:00:05.000 |          0 |
+        |  3 | 2020-01-02 |       2330 |        333   |       45 | 09:00:05.660 |          0 |
+        |  4 | 2020-01-02 |       2330 |        333   |       22 | 09:00:10.000 |          0 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            deal_price: float64, # deal price
+            volume: int64, # volume
+            Time: str, # time
+            TickType: str # tick type (0: undetermined, 1: sell-side, 2: buy-side)
+        }
+        ```
+
+
+#### Fetch all data for a specific date at once (available only to [sponsorpro](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+(Due to the large data volume, each request only provides one day's data.)
+
+- Data range: 2019-01-01 ~ now.
+- Providing the dataset and date parameters returns data for that day.
+- Data update time: **Monday to Friday 15:30**. The actual update time is based on the API data.
+- Some data is missing on this date: 2019-02-20.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_tick(
+            date='2019-01-02',
+            use_object=True,
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+
+        url = "https://api.finmindtrade.com/api/v4/storage_objects"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPriceTick",
+            "date": '2019-01-02',
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = pd.read_parquet(io.BytesIO(resp.content))
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        library(arrow)
+
+        url = 'https://api.finmindtrade.com/api/v4/storage_objects'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPriceTick",
+                date= "2019-01-02"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        con = content(response, "raw")
+        data <- read_parquet(con)
+        close(con)
+        head(data)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   deal_price |   volume | Time     |   TickType |
+        |---:|:-----------|-----------:|-------------:|---------:|:---------|-----------:|
+        |  0 | 2019-01-02 |       0050 |        75.85 |      167 | 09:00:03 |          1 |
+        |  1 | 2019-01-02 |       0050 |        75.90 |       11 | 09:00:08 |          1 |
+        |  2 | 2019-01-02 |       0050 |        75.85 |        2 | 09:00:18 |          1 |
+        |  3 | 2019-01-02 |       0050 |        75.85 |       31 | 09:00:23 |          1 |
+        |  4 | 2019-01-02 |       0050 |        75.85 |       19 | 09:00:28 |          1 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            deal_price: float64, # deal price
+            volume: int64, # volume
+            Time: str, # time
+            TickType: str # tick type (0: undetermined, 1: sell-side, 2: buy-side)
+        }
+        ```
+
+
+----------------------------------
+#### Individual Stock PER, PBR Table TaiwanStockPER
+
+- Data range: 2005-10-01 ~ now
+- Data update time: **Monday to Friday 18:00**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_per_pbr(
+            stock_id='2330',
+            start_date='2020-01-02',
+            end_date='2020-04-12',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPER",
+            "data_id": "2330",
+            "start_date": "2020-04-01",
+            "end_date": "2020-04-12",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPER",
+                data_id= "2330",
+                start_date= "2020-01-02",
+                end_date= "2020-04-12"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_per_pbr(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   dividend_yield |   PER |   PBR |
+        |---:|:-----------|-----------:|-----------------:|------:|------:|
+        |  0 | 2020-01-02 |       2330 |             2.36 | 26.69 |  5.54 |
+        |  1 | 2020-01-03 |       2330 |             2.36 | 26.73 |  5.55 |
+        |  2 | 2020-01-06 |       2330 |             2.41 | 26.14 |  5.42 |
+        |  3 | 2020-01-07 |       2330 |             2.43 | 25.94 |  5.38 |
+        |  4 | 2020-01-08 |       2330 |             2.43 | 25.94 |  5.38 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            dividend_yield: float64, # dividend yield
+            PER: float64, # price-to-earnings ratio
+            PBR: float64 # price-to-book ratio
+        }
+        ```
+
+----------------------------------
+#### Order and Trade Statistics Every 5 Seconds TaiwanStockStatisticsOfOrderBookAndTrade
+(Due to the large data volume, each request only provides one day's data.)
+
+- Data range: 2005-01-01 ~ now
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_book_and_trade(
+            date='2021-01-07'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockStatisticsOfOrderBookAndTrade",
+            "start_date": "2021-01-07",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockStatisticsOfOrderBookAndTrade",
+                start_date= "2021-01-07"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | Time     |   TotalBuyOrder |   TotalBuyVolume |   TotalSellOrder |   TotalSellVolume |   TotalDealOrder |   TotalDealVolume |   TotalDealMoney | date       |
+        |---:|:---------|----------------:|-----------------:|-----------------:|------------------:|-----------------:|------------------:|-----------------:|:-----------|
+        |  0 | 09:00:00 |          298618 |          3229222 |           365465 |           1730137 |                0 |                 0 |                0 | 2021-01-07 |
+        |  1 | 09:00:05 |          301246 |          3254929 |           367886 |           1751034 |            17535 |             97251 |             4515 | 2021-01-07 |
+        |  2 | 09:00:10 |          304171 |          3283698 |           370338 |           1770414 |            31370 |            150557 |             7041 | 2021-01-07 |
+        |  3 | 09:00:15 |          307686 |          3325195 |           372828 |           1782960 |            40083 |            177080 |             8088 | 2021-01-07 |
+        |  4 | 09:00:20 |          310927 |          3345735 |           375220 |           1792055 |            47250 |            198536 |             9137 | 2021-01-07 |
+    === "Schema"
+        ```
+        {
+            Time: str, # time
+            TotalBuyOrder: str, # cumulative number of buy orders
+            TotalBuyVolume: int64, # cumulative buy order volume
+            TotalSellOrder: int64, # cumulative number of sell orders
+            TotalSellVolume: int64, # cumulative sell order volume
+            TotalDealOrder: int64, # cumulative number of trades
+            TotalDealVolume: int64, # cumulative trade volume
+            TotalDealMoney: int64, # cumulative trade amount
+            date: str # date
+        }
+        ```
+
+----------------------------------
+#### Weighted Index TaiwanVariousIndicators5Seconds
+(Due to the large data volume, each request only provides one day's data.)
+
+- Data range: 2005-01-01 ~ now
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.tse(
+            date='2020-07-01'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanVariousIndicators5Seconds",
+            "start_date": "2020-07-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanVariousIndicators5Seconds",
+                start_date="2020-07-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        date = '2025-12-08'
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_various_indicators_5_seconds(
+            data_id_list=['發行量加權股價指數', '未含金融保險股指數'],
+            date=date,
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date                |   TAIEX |
+        |---:|:--------------------|--------:|
+        |  0 | 2020-07-01 09:00:00 | 11621.2 |
+        |  1 | 2020-07-01 09:00:05 | 11622.6 |
+        |  2 | 2020-07-01 09:00:10 | 11632.4 |
+        |  3 | 2020-07-01 09:00:15 | 11643.5 |
+        |  4 | 2020-07-01 09:00:20 | 11644.2 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            TAIEX: float64 # weighted index
+        }
+        ```
+
+----------------------------------
+#### Day Trading Targets and Volume/Value TaiwanStockDayTrading
+
+- Data range: 2014-01-01 ~ now
+- Data update time: **Monday to Friday 21:30**. The actual update time is based on the API data.
+- Sell-first-then-buy suspension markers: Y, ＊
+
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_day_trading(
+            stock_id='2330',
+            start_date='2020-04-02',
+            end_date='2020-04-12'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDayTrading",
+            "data_id": "2330",
+            "start_date": "2020-04-02",
+            "end_date": "2020-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockDayTrading",
+                data_id= "2330",
+                start_date= "2020-04-02",
+                end_date= "2020-04-08"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_day_trading(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    |   stock_id | date       | BuyAfterSale   |   Volume |   BuyAmount |   SellAmount |
+        |---:|-----------:|:-----------|:---------------|---------:|------------:|-------------:|
+        |  0 |       2330 | 2020-04-06 | Y              |  8122000 |  2215280000 |   2218094500 |
+        |  1 |       2330 | 2020-04-07 | Y              |  5128000 |  1450483500 |   1447872000 |
+        |  2 |       2330 | 2020-04-08 | Y              |  2467000 |   702411500 |    702367000 |
+        |  3 |       2330 | 2020-04-09 | Y              |  2583000 |   736745500 |    734035500 |
+        |  4 |       2330 | 2020-04-10 | Y              |  1590000 |   445516000 |    444576000 |
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock code
+            date: str, # date
+            BuyAfterSale: str, # day-trading allowed
+            Volume: int64, # trading volume
+            BuyAmount: int64, # buy amount
+            SellAmount: int64 # sell amount
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_day_trading(
+            start_date='2020-04-06',
+        )
+        ```
+    === "Python-request"
+        ```python
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDayTrading",
+            "start_date": "2020-04-06",
+        }
+        res = requests.get(url, headers=headers, params=parameter)
+        temp = res.json()
+        data = pd.DataFrame(temp["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockDayTrading",
+                start_date= "2020-04-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   stock_id | date       | BuyAfterSale   |   Volume |   BuyAmount |   SellAmount |
+        |---:|-----------:|:-----------|:---------------|---------:|------------:|-------------:|
+        |  0 |       0050 | 2020-04-06 |                |  1296000 |    99116100 |     99343200 |
+        |  1 |       0051 | 2020-04-06 |                |     2000 |       57680 |        57560 |
+        |  2 |       0052 | 2020-04-06 |                |     9000 |      536200 |       537700 |
+        |  3 |       0053 | 2020-04-06 |                |        0 |           0 |            0 |
+        |  4 |       0054 | 2020-04-06 |                |        0 |           0 |            0 |
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock code
+            date: str, # date
+            BuyAfterSale: str, # day-trading allowed
+            Volume: int64, # trading volume
+            BuyAmount: int64, # buy amount
+            SellAmount: int64 # sell amount
+        }
+        ```
+
+----------------------------------
+#### Weighted/OTC Total Return Index TaiwanStockTotalReturnIndex
+
+- Data range: 2003-01-01 ~ now
+- Data update time: **Monday to Friday 16:50**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_total_return_index(
+            index_id="TAIEX",
+            start_date='2020-04-02',
+            end_date='2020-04-12'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockTotalReturnIndex",
+            "data_id": "TAIEX", # TAIEX total return index
+            # "data_id": "TPEx", # TPEx index and total return index
+            "start_date": "2020-04-02",
+            "end_date": "2020-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockTotalReturnIndex",
+                data_id= "TAIEX", # TAIEX total return index
+                # data_id= "TPEx", # TPEx index and total return index
+                start_date= "2020-04-02",
+                end_date= "2020-04-08"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    |   price | stock_id   | date       |
+        |---:|--------:|:-----------|:-----------|
+        |  0 | 18356.5 | TAIEX      | 2020-04-06 |
+        |  1 | 18688.6 | TAIEX      | 2020-04-07 |
+        |  2 | 18952.7 | TAIEX      | 2020-04-08 |
+        |  3 | 18922.6 | TAIEX      | 2020-04-09 |
+        |  4 | 18994   | TAIEX      | 2020-04-10 |
+    === "Schema"
+        ```
+        {
+            price: float64, # total return index
+            stock_id: str, # index code
+            date: str # date
+        }
+        ```
+
+----------------------------------
+#### Taiwan Individual Stock 10-Year Line Table TaiwanStock10Year (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2011-01-24 ~ now
+- The average price is calculated over 2,500 trading days.
+- Data update time: **Monday to Friday 20:00**. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_10year(
+            stock_id='2330',
+            start_date='2020-04-02',
+            end_date='2020-04-12'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStock10Year",
+            "data_id": "2330",
+            "start_date": "2020-04-02",
+            "end_date": "2020-04-12",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStock10Year",
+                data_id= "2330",
+                start_date= "2020-04-02",
+                end_date= "2020-04-12"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_10year(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |    close |
+        |---:|:-----------|-----------:|-----------------:|
+        |  0 | 2020-04-06 |       2330 | 150.16 |
+        |  1 | 2020-04-07 |       2330 | 150.25 |
+        |  2 | 2020-04-08 |       2330 | 150.34 |
+        |  3 | 2020-04-09 |       2330 | 150.43 |
+        |  4 | 2020-04-10 |       2330 | 150.52 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            close: float64 # stock price
+        }
+        ```
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_10year(
+            start_date='2020-04-06',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStock10Year",
+            "start_date": "2020-04-06",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStock10Year",
+                start_date= "2020-04-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   close |
+        |---:|:-----------|-----------:|--------:|
+        |  0 | 2020-04-06 |       0050 |   66.5  |
+        |  1 | 2020-04-06 |       0053 |   28.68 |
+        |  2 | 2020-04-06 |       0055 |   14.31 |
+        |  3 | 2020-04-06 |       0056 |   24.59 |
+        |  4 | 2020-04-06 |       0061 |   16.28 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            close: float64 # stock price
+        }
+        ```
+
+
+----------------------------------
+#### Taiwan Stock Minute K Table TaiwanStockKBar (available only to [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+(Due to the large data volume, each request only provides one day's data.)
+
+- Data range: 2019-01-01 ~ now
+- Data update time: **Monday to Friday 15:50**. The actual update time is based on the API data.
+- Some data is missing on this date: 2019-02-20.
+- Enabling Async significantly reduces the data update time. In a Colab test, downloading 2,175 stocks took only 2 minutes 31 seconds.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_kbar(
+            stock_id='2330',
+            date="2023-09-22"
+        )
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        token = ""
+
+        data_loader = DataLoader()
+        data_loader.login_by_token(token)
+
+        date = '2024-12-20'
+        taiwan_stock_price_df = data_loader.taiwan_stock_daily(start_date=date)
+        # Only fetch stocks with trading volume greater than 0 on the day
+        taiwan_stock_price_df = taiwan_stock_price_df[
+            ["stock_id", "Trading_Volume"]
+        ]
+        taiwan_stock_price_df = taiwan_stock_price_df[
+            taiwan_stock_price_df["Trading_Volume"] > 0
+        ]
+        # Fetch IDs of all listed/OTC stocks whose industry_category is not market index, Index, or all securities,
+        # because these instruments do not have broker breakdown data
+        stock_info_df = data_loader.taiwan_stock_info()
+        stock_info = stock_info_df[stock_info_df["type"].isin(["twse", "tpex"])]
+        cate_mask = stock_info["industry_category"].isin(
+            ["大盤", "Index", "所有證券"]
+        )
+        id_mask = stock_info["stock_id"].isin(["TAIEX", "TPEx"])
+        stock_info = stock_info[~(cate_mask | id_mask)]
+        stock_info = stock_info.merge(
+            taiwan_stock_price_df, how="inner", on=["stock_id"]
+        )
+        stock_info = stock_info[~stock_info["stock_id"].isin(taiwan_stock_price_df)]
+        stock_id_list = list(set(stock_info["stock_id"].values))
+        logger.info(f"len: {len(stock_id_list)}")  # 2175
+        start = datetime.datetime.now()
+        df = data_loader.taiwan_stock_kbar(
+            stock_id_list=stock_id_list,
+            date=date,
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        # 0:02:31.357733
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockKBar",
+            "data_id": "2330",
+            "start_date": "2023-09-22",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockKBar",
+                data_id= "2330",
+                start_date= "2023-09-22"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       | minute   |   stock_id |   open |   high |   low |   close |   volume |
+        |---:|:-----------|:---------|-----------:|-------:|-------:|------:|--------:|---------:|
+        |  0 | 2023-09-22 | 09:00:00 |       2330 |    523 |    524 |   522 |     524 |     3893 |
+        |  1 | 2023-09-22 | 09:01:00 |       2330 |    524 |    524 |   523 |     524 |      159 |
+        |  2 | 2023-09-22 | 09:02:00 |       2330 |    523 |    524 |   522 |     523 |      548 |
+        |  3 | 2023-09-22 | 09:03:00 |       2330 |    522 |    523 |   522 |     522 |      208 |
+        |  4 | 2023-09-22 | 09:04:00 |       2330 |    522 |    523 |   522 |     522 |      179 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            minute: str, # minute
+            stock_id: str, # stock code
+            open: float64, # open price
+            high: float64, # high price
+            low: float64, # low price
+            close: float64, # close price
+            volume: float32 # trading volume
+        }
+        ```
+---------------------------------------
+
+#### Index Statistics Every 5 Seconds TaiwanStockEvery5SecondsIndex (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+(Due to the large data volume, each request only provides one day's data.)
+
+- Data range: 2005-01-03 ~ now
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_every5seconds_index(
+            date='2025-05-09'
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockEvery5SecondsIndex",
+            "start_date": "2025-05-09",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockEvery5SecondsIndex",
+                start_date="2025-05-09"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        date = '2025-12-08'
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_every5seconds_index(
+            data_id_list=['發行量加權股價指數', '未含金融保險股指數'],
+            date=date,
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       | time     | stock_id   |   price | kind   |
+        |---:|:-----------|:---------|:-----------|--------:|:-------|
+        |  0 | 2025-05-09 | 09:00:00 | Automobile |  358.19 | twse   |
+        |  1 | 2025-05-09 | 09:00:05 | Automobile |  358.45 | twse   |
+        |  2 | 2025-05-09 | 09:00:10 | Automobile |  358.19 | twse   |
+        |  3 | 2025-05-09 | 09:00:15 | Automobile |  357.63 | twse   |
+        |  4 | 2025-05-09 | 09:00:20 | Automobile |  357.65 | twse   |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            time: str, # time
+            stock_id: str, # industry code
+            price: float, # price
+            kind: str # market type
+        }
+        ```
+
+----------------------------------
+#### Taiwan Stock Suspension Announcement TaiwanStockSuspended (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2011-10-06 ~ now
+- Records announcements of trading suspension on individual stocks due to material information, shareholder meetings, disposition, etc., including suspension start date/time and expected resumption date/time.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_suspended(
+            start_date='2017-04-01',
+            end_date='2025-01-01',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockSuspended",
+            "start_date": "2017-04-01",
+            "end_date": "2025-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockSuspended",
+                start_date= "2017-04-01",
+                end_date= "2025-01-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    | date       | stock_id | suspension_time | resumption_date | resumption_time |
+        |---:|:-----------|:---------|:----------------|:----------------|:----------------|
+        |  0 | 2017-04-19 | 1101     | 8:00            | 2017-04-21      | 8:00            |
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock code
+            date: str, # suspension date
+            suspension_time: str, # suspension time
+            resumption_date: str, # resumption date
+            resumption_time: str # resumption time
+        }
+        ```
+
+----------------------------------
+#### Day Trading Sell-First-Then-Buy Suspension Notice TaiwanStockDayTradingSuspension (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data range: 2014-06-01 ~ now
+- Records advance notices of suspension of "sell-first-then-buy" day trading on individual stocks, with common reasons including ex-rights and ex-dividend events, and includes the suspension start and end dates.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_day_trading_suspension(
+            start_date='2024-12-01',
+            end_date='2025-01-01',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockDayTradingSuspension",
+            "start_date": "2024-12-01",
+            "end_date": "2025-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        token = "" # Refer to login to obtain the token
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockDayTradingSuspension",
+                start_date= "2024-12-01",
+                end_date= "2025-01-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = response %>% content
+        df = do.call('cbind',data$data) %>%data.table
+        head(df)
+        ```
+!!! output
+    === "DataFrame"
+        |    | stock_id | date       | end_date   | reason |
+        |---:|:---------|:-----------|:-----------|:-------|
+        |  0 | 00940    | 2024-12-27 | 2025-01-03 | 除息   |
+    === "Schema"
+        ```
+        {
+            stock_id: str, # stock code
+            date: str, # sell-first-then-buy suspension start date
+            end_date: str, # sell-first-then-buy suspension end date
+            reason: str # reason
+        }
+        ```
+
+----------------------------------
+#### Daily Price Limit TaiwanStockPriceLimit (available only to backer, sponsor members)
+
+- Data range: 2000-01-01 ~ now
+- Data update time: **Monday to Friday 18:00**
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_price_limit(
+            stock_id='2330',
+            start_date='2023-01-01',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPriceLimit",
+            "data_id": "2330",
+            "start_date": "2023-01-01",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPriceLimit",
+                data_id="2330",
+                start_date= "2023-01-01"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+    === "Package-Async"
+        ```python
+        from FinMind.data import DataLoader
+        from loguru import logger
+        import datetime
+
+        api = DataLoader()
+        api.login_by_token(api_token='token')
+
+        start = datetime.datetime.now()
+        df = api.taiwan_stock_price_limit(
+            stock_id_list=['2330', '2317', '2454', '3008'],
+            start_date='2024-01-01',
+            end_date='2024-12-31',
+            use_async=True,
+        )
+        cost = datetime.datetime.now() - start
+        logger.info(cost)
+        ```
+
+
+!!! output
+    === "DataFrame"
+        |    | date       | stock_id | reference_price | limit_up | limit_down |
+        |---:|:-----------|:---------|----------------:|---------:|-----------:|
+        |  0 | 2023-01-03 | 2330     |          450.00 |   495.00 |     405.00 |
+        |  1 | 2023-01-04 | 2330     |          452.00 |   497.00 |     407.00 |
+        |  2 | 2023-01-05 | 2330     |          452.50 |   497.50 |     407.50 |
+        |  3 | 2023-01-06 | 2330     |          454.50 |   500.00 |     409.00 |
+        |  4 | 2023-01-09 | 2330     |          458.00 |   503.50 |     412.50 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            reference_price: float64, # reference price
+            limit_up: float64, # limit-up price (0 means no price-limit applies)
+            limit_down: float64 # limit-down price (0 means no price-limit applies)
+        }
+        ```
+
+!!! note
+    When `limit_up` and `limit_down` are **0**, this means the instrument has no price-limit, including:
+
+    - Leveraged ETFs (e.g., 00631L)
+    - Inverse ETFs (e.g., 00632R)
+    - Emerging stocks
+
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_price_limit(
+            start_date='2023-01-03',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPriceLimit",
+            "start_date": "2023-01-03",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPriceLimit",
+                start_date= "2023-01-03"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```

--- a/docs/tutor/UnitedKingdomMarket/DataList.en.md
+++ b/docs/tutor/UnitedKingdomMarket/DataList.en.md
@@ -1,0 +1,9 @@
+In the UK financial market, we offer 1 dataset, as follows:
+
+- [UK Stock List UKStockInfo](https://finmind.github.io/en/tutor/UnitedKingdomMarket/Technical/#ukstockinfo)
+
+#### Stock Price TaiwanStock
+
+- [UK Stock Price Table UKStockPrice](https://finmind.github.io/en/tutor/UnitedKingdomMarket/Technical/#ukstockprice)
+
+For specific schemas, please refer to [finmind](https://finmindtrade.com/analysis/#/data/document)

--- a/docs/tutor/UnitedKingdomMarket/Technical.en.md
+++ b/docs/tutor/UnitedKingdomMarket/Technical.en.md
@@ -1,0 +1,94 @@
+In UK stock data, we offer 1 dataset, as follows:
+
+- [UK Stock Price Table UKStockPrice](https://finmind.github.io/en/tutor/UnitedKingdomMarket/Technical/#ukstockprice)
+
+In addition, the following list summarizes the available datasets:
+
+- [UK Stock List UKStockInfo](https://finmind.github.io/en/tutor/UnitedKingdomMarket/Technical/#ukstockinfo)
+
+The usage of each dataset is explained one by one below. For the specific dataset schemas, please refer to [finmindapi](http://api.finmindtrade.com/docs#/default/method_api_v3_data_get)
+
+#### UK Stock List UKStockInfo
+
+- This dataset primarily lists the names, codes, and industry categories of all UK listed and OTC stocks.
+
+!!! example
+   ```python
+   import requests
+   import pandas as pd
+
+   url = 'https://api.finmindtrade.com/api/v4/data'
+   token = "" # Refer to the login page to obtain your API key
+   headers = {"Authorization": f"Bearer {token}"}
+   parameter = {
+      "dataset": "UKStockInfo"
+   }
+   data = requests.get(url, headers=headers, params=parameter)
+   data = data.json()
+   data = pd.DataFrame(data['data'])
+   print(data.head())
+   ```
+!!! output
+    === "DataFrame"
+         |    | date       | stock_id   | Country   | stock_name      |
+         |---:|:-----------|:-----------|:----------|:----------------|
+         |  0 | 2019-01-31 | 01IC.L     | USD       | QUEBEC FRN20    |
+         |  1 | 2019-01-31 | 01IE.L     | USD       | ROY.BK.SCOTSERB |
+         |  2 | 2019-01-31 | 01KG.L     | GBP       | SCOT.AMER.8%DB. |
+         |  3 | 2019-01-31 | 01LQ.L     | GBP       | SCOT.PWR.UK6T23 |
+         |  4 | 2019-01-31 | 01LT.L     | GBP       | RES.MORT.4CTBRA |
+    === "Schema"
+        ```
+        {
+            date: str,
+            stock_id: str,
+            Country: str,
+            stock_name: str
+        }
+        ```
+
+
+#### UK Stock Price Table UKStockPrice
+
+!!! example
+   ```python
+   import requests
+   import pandas as pd
+
+   url = 'https://api.finmindtrade.com/api/v4/data'
+   token = "" # Refer to the login page to obtain your API key
+   headers = {"Authorization": f"Bearer {token}"}
+   parameter = {
+      "dataset": "UKStockPrice",
+      "data_id": "BP.L",
+      "start_date": "2020-06-16",
+      "end_date": "2021-06-16",
+   }
+   data = requests.get(url, headers=headers, params=parameter)
+   data = data.json()
+   data = pd.DataFrame(data['data'])
+   print(data.head())
+   ```
+!!! output
+    === "DataFrame"
+         |    | date       | stock_id   |   Adj_Close |   Close |   High |    Low |   Open |   Volume |
+         |---:|:-----------|:-----------|------------:|--------:|-------:|-------:|-------:|---------:|
+         |  0 | 2020-06-16 | BP.L       |      290.26 |  321.65 | 331.8  | 318.65 | 322.15 | 55470516 |
+         |  1 | 2020-06-17 | BP.L       |      285.84 |  316.75 | 328.35 | 315.1  | 322.85 | 38005133 |
+         |  2 | 2020-06-18 | BP.L       |      284.13 |  314.85 | 316.7  | 308.9  | 313.9  | 33988764 |
+         |  3 | 2020-06-19 | BP.L       |      290.08 |  321.45 | 325.95 | 315.7  | 316.8  | 95409968 |
+         |  4 | 2020-06-22 | BP.L       |      284.67 |  315.45 | 318.9  | 311.1  | 318.15 | 58369094 |
+    === "Schema"
+        ```
+        {
+            date: str,
+            stock_id: str,
+            Adj_Close: float32,
+            Close: float32,
+            High: float32,
+            Low: float32,
+            Open: float32,
+            Volume: int64
+        }
+        ```
+

--- a/docs/tutor/UnitedStatesMarket/DataList.en.md
+++ b/docs/tutor/UnitedStatesMarket/DataList.en.md
@@ -1,0 +1,11 @@
+In the US financial market, we offer 1 dataset, as follows:
+
+- [US Stock List USStockInfo](https://finmind.github.io/en/tutor/UnitedStatesMarket/Technical/#usstockinfo)
+
+#### Stock Price TaiwanStock
+
+- [US Stock Minute K Price Table USStockPriceMinute](https://finmind.github.io/en/tutor/UnitedStatesMarket/Technical/#k-usstockpriceminute-backersponsor)
+- [US Stock Price Table USStockPrice](https://finmind.github.io/en/tutor/UnitedStatesMarket/Technical/#usstockprice)
+
+
+For specific schemas, please refer to [finmind](https://finmindtrade.com/analysis/#/data/document)

--- a/docs/tutor/UnitedStatesMarket/Technical.en.md
+++ b/docs/tutor/UnitedStatesMarket/Technical.en.md
@@ -1,0 +1,142 @@
+In US stock data, we offer 2 datasets, as follows:
+
+- [US Stock Minute K Price Table USStockPriceMinute](https://finmind.github.io/en/tutor/UnitedStatesMarket/Technical/#k-usstockpriceminute-backersponsor)
+- [US Stock Price Table USStockPrice](https://finmind.github.io/en/tutor/UnitedStatesMarket/Technical/#usstockprice)
+
+In addition, the following list summarizes the available datasets:
+
+- [US Stock List USStockInfo](https://finmind.github.io/en/tutor/UnitedStatesMarket/Technical/#usstockinfo)
+
+The usage of each dataset is explained one by one below. For the specific dataset schemas, please refer to [finmindapi](http://api.finmindtrade.com/docs#/default/method_api_v3_data_get)
+
+#### US Stock List USStockInfo
+
+- This dataset primarily lists the names, codes, and industry categories of all US listed and OTC stocks.
+
+!!! example
+    ```python
+    import requests
+    import pandas as pd
+
+    url = 'https://api.finmindtrade.com/api/v4/data'
+    token = "" # Refer to the login page to obtain your API key
+    headers = {"Authorization": f"Bearer {token}"}
+    parameter = {
+        "dataset": "USStockInfo"
+    }
+    data = requests.get(url, headers=headers, params=parameter)
+    data = data.json()
+    data = pd.DataFrame(data['data'])
+    print(data.head())
+    ```
+
+!!! output
+    === "DataFrame"
+        |    | date       | stock_id   | Country       |   IPOYear |   MarketCap | Subsector                                     | stock_name                    |
+        |---:|:-----------|:-----------|:--------------|----------:|------------:|:----------------------------------------------|:------------------------------|
+        |  0 | 2019-01-10 | A          | United States |      1999 | 21610000000 | Biotechnology:LaboratoryAnalyticalInstruments | Agilent Technologies, Inc.    |
+        |  1 | 2019-01-10 | AA         | n/a           |      2016 |  5270000000 | Aluminum                                      | Alcoa Corporation             |
+        |  2 | 2019-01-10 | AABA       | United States |         0 | 36780000000 | EDPServices                                   | Altaba Inc.                   |
+        |  3 | 2019-01-10 | AAC        | United States |      2014 |    55360000 | MedicalSpecialities                           | AAC Holdings, Inc.            |
+        |  4 | 2019-01-10 | AAL        | United States |         0 | 14930000000 | AirFreight/DeliveryServices                   | American Airlines Group, Inc. |
+    === "Schema"
+        ```
+        {
+            date: str,
+            stock_id: str,
+            Country: str,
+            IPOYear: str,
+            MarketCap: str,
+            Subsector: str,
+            stock_name: str
+        }
+        ```
+
+#### US Stock Minute K Price Table USStockPriceMinute (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+- Data update time **08:00 daily**. Actual update time is based on the API data.
+
+!!! example
+    ```python
+    import requests
+    import pandas as pd
+
+    url = 'https://api.finmindtrade.com/api/v4/data'
+    token = "" # Refer to the login page to obtain your API key
+    headers = {"Authorization": f"Bearer {token}"}
+    parameter = {
+        "dataset": "USStockPriceMinute",
+        "data_id": "^DJI",
+        "start_date": "2022-06-16",
+    }
+    data = requests.get(url, headers=headers, params=parameter)
+    data = data.json()
+    data = pd.DataFrame(data['data'])
+    print(data.head())
+    ```
+!!! output
+    === "DataFrame"
+        |    | date                | stock_id   |   close |    high |     low |    open |   volume |
+        |---:|:--------------------|:-----------|--------:|--------:|--------:|--------:|---------:|
+        |  0 | 2022-06-16 13:31:00 | ^DJI       | 30082.5 | 30094.9 | 30076.6 | 30091.4 |  1686944 |
+        |  1 | 2022-06-16 13:32:00 | ^DJI       | 30075.6 | 30087.9 | 30069.2 | 30081.7 |  1939377 |
+        |  2 | 2022-06-16 13:33:00 | ^DJI       | 30039.5 | 30085.8 | 30036.4 | 30078.1 |  1589351 |
+        |  3 | 2022-06-16 13:34:00 | ^DJI       | 30001.6 | 30036.5 | 29995.9 | 30036.5 |  2127155 |
+        |  4 | 2022-06-16 13:35:00 | ^DJI       | 29996.7 | 30008   | 29984.3 | 30002.2 |  1917277 |
+    === "Schema"
+        ```
+        {
+            date: str,
+            stock_id: str,
+            close: float64,
+            high: float64,
+            low: float64,
+            open: float64,
+            volume: int64
+        }
+        ```
+
+#### US Stock Price Table USStockPrice
+
+- Data update time **08:00 daily**. Actual update time is based on the API data.
+
+!!! example
+    ```python
+    import requests
+    import pandas as pd
+
+    url = 'https://api.finmindtrade.com/api/v4/data'
+    token = "" # Refer to the login page to obtain your API key
+    headers = {"Authorization": f"Bearer {token}"}
+    parameter = {
+        "dataset": "USStockPrice",
+        "data_id": "^DJI",
+        "start_date": "2020-06-16",
+        "end_date": "2021-06-16",
+    }
+    data = requests.get(url, headers=headers, params=parameter)
+    data = data.json()
+    data = pd.DataFrame(data['data'])
+    print(data.head())
+    ```
+!!! output
+    === "DataFrame"
+        |    | date       | stock_id   |   Adj_Close |   Close |    High |     Low |    Open |    Volume |
+        |---:|:-----------|:-----------|------------:|--------:|--------:|--------:|--------:|----------:|
+        |  0 | 2020-06-16 | ^DJI       |     26290   | 26290   | 26611   | 25811.7 | 26326.7 | 489500000 |
+        |  1 | 2020-06-17 | ^DJI       |     26119.6 | 26119.6 | 26400.1 | 26068.4 | 26330.5 | 328830000 |
+        |  2 | 2020-06-18 | ^DJI       |     26080.1 | 26080.1 | 26154.2 | 25848.5 | 26016.5 | 328390000 |
+        |  3 | 2020-06-19 | ^DJI       |     25871.5 | 25871.5 | 26451.4 | 25759.7 | 26213.1 | 669390000 |
+        |  4 | 2020-06-22 | ^DJI       |     26025   | 26025   | 26059.8 | 25667.7 | 25865.1 | 351780000 |
+    === "Schema"
+        ```
+        {
+            date: str,
+            stock_id: str,
+            close: float64,
+            high: float64,
+            low: float64,
+            open: float64,
+            volume: int64
+        }
+        ```

--- a/docs/tutor/analysis/Backtesting.en.md
+++ b/docs/tutor/analysis/Backtesting.en.md
@@ -1,0 +1,160 @@
+
+### [Online Link](https://colab.research.google.com/drive/1Unn7pSbp4RxQQRWaBJaC3oACdUFML4Xu?usp=sharing)
+
+The following code shows how to use FinMind to perform strategy backtesting. The backtest is mainly driven by **strategies**, while **DataLoader** reads the data provided by FinMind.
+
+When running a backtest, you mainly need to first decide the backtest target, the backtest period, the funding amount, the trading tax, and the design of the strategy.
+
+The backtest logic is mainly to determine the **entry, hold, and exit** signals. For example:
+
+    - If today's calculated signal is -1, it means tomorrow 1 lot of stock will be **sold** at the opening price
+    - If today's calculated signal is 0, it means do nothing tomorrow
+    - If today's calculated signal is 1, it means tomorrow 1 lot of stock will be **bought** at the opening price
+
+The backtest result provides the following information:
+
+    - trade_detail: Detailed backtest data
+    - compare_market_detail: Trends of cumulative market return and cumulative backtest return
+    - final_stats: Backtest result
+    - compare_market_stats: Annualized return of the market and annualized return of the strategy
+
+In the example program, it is mainly divided into using the strategies provided by FinMind and customized strategies.
+
+!!! info "Initialization: set backtest stock id and time period"
+
+     ```python
+     import numpy as np
+     import pandas as pd
+     from FinMind import strategies
+     from FinMind.data import DataLoader
+     from FinMind.strategies.base import Strategy
+     from ta.momentum import StochasticOscillator
+
+
+     data_loader = DataLoader()
+     # data_loader.login_by_token(api_token='token') # optional
+     obj = strategies.BackTest(
+          stock_id="0056",
+          start_date="2018-01-01",
+          end_date="2019-01-01",
+          trader_fund=500000.0,
+          fee=0.001425,
+          data_loader=data_loader,
+     )
+     obj.stock_price
+
+     ```
+
+!!! done "The backtest will be calculated using the following data"
+
+     ```python
+               date stock_id  Trading_Volume  Trading_money   open    max    min  close  spread  Trading_turnover  CashEarningsDistribution  StockEarningsDistribution
+     0    2018-01-02     0056         1868451       46856990  25.00  25.14  25.00  25.13    0.13             733.0                       0.0                        0.0
+     1    2018-01-03     0056         3846820       97179269  25.15  25.31  25.15  25.31    0.18            1202.0                       0.0                        0.0
+     2    2018-01-04     0056         2736229       69496928  25.31  25.45  25.31  25.41    0.10             957.0                       0.0                        0.0
+     3    2018-01-05     0056         2383585       60620826  25.41  25.48  25.39  25.44    0.03             782.0                       0.0                        0.0
+     4    2018-01-08     0056         3048596       77817525  25.45  25.57  25.45  25.57    0.13            1236.0                       0.0                        0.0
+     ..          ...      ...             ...            ...    ...    ...    ...    ...     ...               ...                       ...                        ...
+     242  2018-12-24     0056         1501284       36271556  24.20  24.21  24.09  24.18    0.01             773.0                       0.0                        0.0
+     243  2018-12-25     0056        13908880      332473777  24.01  24.06  23.84  23.97   -0.21            6359.0                       0.0                        0.0
+     244  2018-12-26     0056        12600245      300239138  24.09  24.09  23.67  23.72   -0.25            6413.0                       0.0                        0.0
+     245  2018-12-27     0056         2986526       71566004  24.00  24.02  23.90  23.91    0.19            1651.0                       0.0                        0.0
+     246  2018-12-28     0056         2657586       63571334  23.93  23.96  23.89  23.94    0.03            1075.0                       0.0                        0.0
+     ```
+
+
+!!! info "Design Strategy"
+
+     ```python
+     class Kd(Strategy):
+          """
+          summary:
+               Daily KD 80 20
+               Daily K-line <= 20 enter
+               Daily K-line >= 80 exit
+          """
+          kdays = 9
+          kd_upper = 80
+          kd_lower = 20
+          def create_trade_sign(self, stock_price: pd.DataFrame) -> pd.DataFrame:
+               stock_price = stock_price.sort_values("date")
+               kd = StochasticOscillator(
+                    high=stock_price["max"],
+                    low=stock_price["min"],
+                    close=stock_price["close"],
+                    n=self.kdays,
+               )
+               rsv_ = kd.stoch().fillna(50)
+               _k = np.zeros(stock_price.shape[0])
+               _d = np.zeros(stock_price.shape[0])
+               for i, r in enumerate(rsv_):
+                    if i == 0:
+                         _k[i] = 50
+                         _d[i] = 50
+                    else:
+                         _k[i] = _k[i - 1] * 2 / 3 + r / 3
+                         _d[i] = _d[i - 1] * 2 / 3 + _k[i] / 3
+               stock_price["K"] = _k
+               stock_price["D"] = _d
+               stock_price.index = range(len(stock_price))
+               stock_price["signal"] = 0
+               stock_price.loc[stock_price["K"] <= self.kd_lower, "signal"] = 1
+               stock_price.loc[stock_price["K"] >= self.kd_upper, "signal"] = -1
+               return stock_price
+     ```
+
+
+!!! info "Backtest simulated trading"
+
+     ```python
+     obj.add_strategy(Kd)
+     obj.simulate()
+     obj.final_stats
+     ```
+
+!!! done "output"
+
+     ```python
+     MeanProfit          2366.450976
+     MaxLoss            -1425.510000
+     FinalProfit         6196.970000
+     MeanProfitPer          0.470000
+     FinalProfitPer         1.240000
+     MaxLossPer            -0.290000
+     AnnualReturnPer        1.250000
+     AnnualSharpRatio       0.860000
+     dtype: float64
+     ```
+
+!!! info "Trade Details"
+
+     ```python
+     obj.trade_detail
+     ```
+
+!!! done "output"
+
+     ```python
+     stock_id        date  EverytimeProfit  RealizedProfit  UnrealizedProfit  board_lot  hold_cost  hold_volume  signal    tax       fee  trade_price   trader_fund
+     0       0056  2018-01-03             0.00            0.00              0.00       1000   0.000000            0       0  0.001  0.001425        25.15  500000.00000
+     1       0056  2018-01-04             0.00            0.00              0.00       1000   0.000000            0       0  0.001  0.001425        25.31  500000.00000
+     2       0056  2018-01-05             0.00            0.00              0.00       1000   0.000000            0       0  0.001  0.001425        25.41  500000.00000
+     3       0056  2018-01-08             0.00            0.00              0.00       1000   0.000000            0       0  0.001  0.001425        25.45  500000.00000
+     4       0056  2018-01-09             0.00            0.00              0.00       1000   0.000000            0       0  0.001  0.001425        25.55  500000.00000
+     ..       ...         ...              ...             ...               ...        ...        ...          ...     ...    ...       ...          ...           ...
+     241     0056  2018-12-24          7274.35         5677.56           1596.79       1000  23.742118         4000       0  0.001  0.001425        24.20  410709.09425
+     242     0056  2018-12-25          6516.19         5677.56            838.63       1000  23.742118         4000       0  0.001  0.001425        24.01  410709.09425
+     243     0056  2018-12-26          6835.42         5677.56           1157.86       1000  23.742118         4000       0  0.001  0.001425        24.09  410709.09425
+     244     0056  2018-12-27          6476.29         5677.56            798.73       1000  23.742118         4000       0  0.001  0.001425        24.00  410709.09425
+     245     0056  2018-12-28          6196.97         5677.56            519.41       1000  23.742118         4000       0  0.001  0.001425        23.93  410709.09425
+     ```
+
+
+!!! info "Visualization"
+
+     ```python
+     obj.plot()
+     ```
+
+![backtesting](https://finmind.github.io/images/backtesting.png)
+

--- a/docs/tutor/analysis/BacktestingOtherData.en.md
+++ b/docs/tutor/analysis/BacktestingOtherData.en.md
@@ -1,0 +1,195 @@
+
+### [Online Link](https://colab.research.google.com/drive/1E9pvGTj5R4y7QBhqtzApF5KumeYE855r?usp=sharing)
+
+```
+pip install FinMind
+```
+
+
+!!! info "Initialization: set backtest stock id and time period"
+
+    ```python
+    import numpy as np
+    import pandas as pd
+    from FinMind import strategies
+    from FinMind.data import DataLoader
+    from FinMind.strategies.base import Strategy
+    from ta.momentum import StochasticOscillator
+
+    data_loader = DataLoader()
+    # data_loader.login_by_token(api_token='token') # optional
+    obj = strategies.BackTest(
+        stock_id="0056",
+        start_date="2018-01-01",
+        end_date="2019-01-01",
+        trader_fund=500000.0,
+        fee=0.001425,
+        data_loader=data_loader,
+    )
+    obj.stock_price
+    ```
+
+!!! done "The backtest will be calculated using the following data"
+    ```python
+            date stock_id  Trading_Volume  Trading_money   open    max    min  close  spread  Trading_turnover  CashEarningsDistribution  StockEarningsDistribution
+    0    2018-01-02     2330        18055269     4188555408  231.5  232.5  231.0  232.5     3.0            9954.0                       0.0                        0.0
+    1    2018-01-03     2330        31706091     7504382512  236.0  238.0  235.5  237.0     4.5           13633.0                       0.0                        0.0
+    2    2018-01-04     2330        29179613     6963192636  240.0  240.0  236.5  239.5     2.5           10953.0                       0.0                        0.0
+    3    2018-01-05     2330        23721255     5681934695  240.0  240.0  238.0  240.0     0.5            8659.0                       0.0                        0.0
+    4    2018-01-08     2330        21846692     5281823362  242.0  242.5  240.5  242.0     2.0           10251.0                       0.0                        0.0
+    ..          ...      ...             ...            ...    ...    ...    ...    ...     ...               ...                       ...                        ...
+    729  2020-12-25     2330        12581145     6449612552  514.0  515.0  510.0  511.0     1.0           14988.0                       0.0                        0.0
+    730  2020-12-28     2330        19262886     9890545245  512.0  515.0  509.0  515.0     4.0           16673.0                       0.0                        0.0
+    731  2020-12-29     2330        20151736    10370562545  515.0  517.0  513.0  515.0     0.0           17186.0                       0.0                        0.0
+    732  2020-12-30     2330        46705107    24306881615  516.0  525.0  514.0  525.0    10.0           33173.0                       0.0                        0.0
+    733  2020-12-31     2330        30326332    15989936054  526.0  530.0  524.0  530.0     5.0           25134.0                       0.0                        0.0
+    ```
+
+!!! info "Design Strategy"
+
+    ```python hl_lines="13 36"
+    class ShortSaleMarginPurchaseRatio(Strategy):
+        """
+        summary:
+            Strategy concept: A higher short-sale-to-margin-purchase ratio means retail investors are bearish.
+            When institutional investors are net buyers and the stock price tends to rise, we can take the
+            opposite action of most retail investors by selling, and vice versa.
+            Strategy rules: short-sale-to-margin-purchase ratio >= 30% and institutional investors net buy, sell
+                           short-sale-to-margin-purchase ratio < 30% and institutional investors net sell, buy
+        """
+
+        ShortSaleMarginPurchaseTodayRatioThreshold = 0.3
+
+        def load_taiwan_stock_margin_purchase_short_sale(self):
+            self.TaiwanStockMarginPurchaseShortSale = (
+                self.data_loader.taiwan_stock_margin_purchase_short_sale(
+                    stock_id=self.stock_id,
+                    start_date=self.start_date,
+                    end_date=self.end_date,
+                )
+            )
+            self.TaiwanStockMarginPurchaseShortSale[
+                ["ShortSaleTodayBalance", "MarginPurchaseTodayBalance"]
+            ] = self.TaiwanStockMarginPurchaseShortSale[
+                ["ShortSaleTodayBalance", "MarginPurchaseTodayBalance"]
+            ].astype(
+                int
+            )
+            self.TaiwanStockMarginPurchaseShortSale[
+                "ShortSaleMarginPurchaseTodayRatio"
+            ] = (
+                self.TaiwanStockMarginPurchaseShortSale["ShortSaleTodayBalance"]
+                / self.TaiwanStockMarginPurchaseShortSale[
+                    "MarginPurchaseTodayBalance"
+                ]
+            )
+
+        def load_institutional_investors_buy_sell(self):
+            self.InstitutionalInvestorsBuySell = (
+                self.data_loader.taiwan_stock_institutional_investors(
+                    stock_id=self.stock_id,
+                    start_date=self.start_date,
+                    end_date=self.end_date,
+                )
+            )
+            self.InstitutionalInvestorsBuySell[["sell", "buy"]] = (
+                self.InstitutionalInvestorsBuySell[["sell", "buy"]]
+                .fillna(0)
+                .astype(int)
+            )
+            self.InstitutionalInvestorsBuySell = (
+                self.InstitutionalInvestorsBuySell.groupby(
+                    ["date", "stock_id"], as_index=False
+                ).agg({"buy": np.sum, "sell": np.sum})
+            )
+            self.InstitutionalInvestorsBuySell["diff"] = (
+                self.InstitutionalInvestorsBuySell["buy"]
+                - self.InstitutionalInvestorsBuySell["sell"]
+            )
+
+        def create_trade_sign(self, stock_price: pd.DataFrame) -> pd.DataFrame:
+            stock_price = stock_price.sort_values("date")
+            self.load_taiwan_stock_margin_purchase_short_sale()
+            self.load_institutional_investors_buy_sell()
+            stock_price = pd.merge(
+                stock_price,
+                self.InstitutionalInvestorsBuySell[["stock_id", "date", "diff"]],
+                on=["stock_id", "date"],
+                how="left",
+            ).fillna(0)
+            stock_price = pd.merge(
+                stock_price,
+                self.TaiwanStockMarginPurchaseShortSale[
+                    ["stock_id", "date", "ShortSaleMarginPurchaseTodayRatio"]
+                ],
+                on=["stock_id", "date"],
+                how="left",
+            ).fillna(0)
+            stock_price.index = range(len(stock_price))
+            stock_price["signal"] = 0
+            sell_mask = (
+                stock_price["ShortSaleMarginPurchaseTodayRatio"]
+                >= self.ShortSaleMarginPurchaseTodayRatioThreshold
+            ) & (stock_price["diff"] > 0)
+            stock_price.loc[sell_mask, "signal"] = -1
+            buy_mask = (
+                stock_price["ShortSaleMarginPurchaseTodayRatio"]
+                < self.ShortSaleMarginPurchaseTodayRatioThreshold
+            ) & (stock_price["diff"] < 0)
+            stock_price.loc[buy_mask, "signal"] = 1
+            return stock_price
+    ```
+
+!!! info "Backtest simulated trading"
+
+    ```python
+    obj.add_strategy(ShortSaleMarginPurchaseRatio)
+    obj.simulate()
+    obj.final_stats
+    ```
+
+!!! done "output"
+
+    ```python
+    MeanProfit          187013.454352
+    MaxLoss             -17592.160000
+    FinalProfit         716596.810000
+    MeanProfitPer           37.400000
+    FinalProfitPer         143.320000
+    MaxLossPer              -3.520000
+    AnnualReturnPer         34.500000
+    AnnualSharpRatio         1.430000
+    dtype: float64
+    ```
+
+!!! info "Trade Details"
+
+    ```python
+     obj.trade_detail
+    ```
+
+!!! done "output"
+
+    ```python
+        stock_id        date  EverytimeProfit  RealizedProfit  UnrealizedProfit  board_lot  hold_cost  hold_volume  signal    tax       fee  trade_price  trader_fund
+    0       2330  2018-01-03             0.00            0.00              0.00       1000     0.0000            0       0  0.003  0.001425        236.0   500000.000
+    1       2330  2018-01-04             0.00            0.00              0.00       1000     0.0000            0       0  0.003  0.001425        240.0   500000.000
+    2       2330  2018-01-05             0.00            0.00              0.00       1000     0.0000            0       0  0.003  0.001425        240.0   500000.000
+    3       2330  2018-01-08             0.00            0.00              0.00       1000     0.0000            0      -1  0.003  0.001425        242.0   500000.000
+    4       2330  2018-01-09             0.00            0.00              0.00       1000     0.0000            0      -1  0.003  0.001425        242.0   500000.000
+    ..       ...         ...              ...             ...               ...        ...        ...          ...     ...    ...       ...          ...          ...
+    728     2330  2020-12-25        692703.01       160992.91         531710.10       1000   245.8705         2000       0  0.003  0.001425        514.0    47251.925
+    729     2330  2020-12-28        688720.71       160992.91         527727.80       1000   245.8705         2000       0  0.003  0.001425        512.0    47251.925
+    730     2330  2020-12-29        694694.16       160992.91         533701.25       1000   245.8705         2000       0  0.003  0.001425        515.0    47251.925
+    731     2330  2020-12-30        696685.31       160992.91         535692.40       1000   245.8705         2000       0  0.003  0.001425        516.0    47251.925
+    732     2330  2020-12-31        716596.81       160992.91         555603.90       1000   245.8705         2000       0  0.003  0.001425        526.0    47251.925
+    ```
+
+
+!!! info "Visualization"
+     ```python
+     obj.plot()
+     ```
+
+![backtesting](https://finmind.github.io/images/backtesting_other_data.png)
+

--- a/docs/tutor/analysis/CustomerDashboardWebServer.en.md
+++ b/docs/tutor/analysis/CustomerDashboardWebServer.en.md
@@ -1,0 +1,143 @@
+## Build a Customized Dashboard and Host a Web Server Locally
+
+![png](https://finmind.github.io/images/dashboard_flask.png)
+
+!!! info "K-Line"
+     ```python
+     from pathlib import Path
+
+     from flask import Flask, render_template, request
+     from loguru import logger
+     from pyecharts.charts import Page
+
+     import FinMind
+     from FinMind import plotting
+     from FinMind.data import DataLoader
+
+
+     def get_path():
+          path = Path(FinMind.__file__)
+          path = path.parent.joinpath("templates")
+          return path
+
+
+     PATH = get_path()
+
+
+     def kline(data_loader: DataLoader, stock_id: str, start_date: str, end_date: str):
+          stock_data = data_loader.taiwan_stock_daily(stock_id, start_date, end_date)
+          stock_data = data_loader.feature.add_kline_institutional_investors(
+               stock_data
+          )
+          stock_data = data_loader.feature.add_kline_margin_purchase_short_sale(
+               stock_data
+          )
+          # Plot the K-line chart
+          kline_plot = plotting.kline(stock_data)
+          return kline_plot
+
+     ```
+
+!!! info "Monthly Revenue, Bar Chart"
+     ```python
+     def bar(data_loader: DataLoader, stock_id: str, start_date: str, end_date: str):
+          df = data_loader.taiwan_stock_month_revenue(
+               stock_id=stock_id, start_date=start_date, end_date=end_date
+          )
+          df["labels"] = (
+               df[["revenue_year", "revenue_month"]]
+               .astype(str)
+               .apply(lambda date: f"{date[0]}-{date[1]}M", axis=1)
+          )
+          df["series"] = df["revenue"].map(lambda value: round(value * 1e-8, 2))
+          bar_plot = plotting.bar(
+               labels=df["labels"],
+               series=df["series"],
+               title="Monthly Revenue",
+               yaxis_color="orange",
+               y_axis_name="100M",
+          )
+          return bar_plot
+
+     ```
+     
+!!! info "Foreign Investor Shareholding Ratio, Line Chart"
+     ```python
+     def line(data_loader: DataLoader, stock_id: str, start_date: str, end_date: str):
+          df = data_loader.taiwan_stock_shareholding(
+               stock_id=stock_id, start_date=start_date, end_date=end_date
+          )
+          df["series"] = df["ForeignInvestmentSharesRatio"].map(
+               lambda value: round(value * 1e-2, 2)
+          )
+          df["labels"] = df["date"]
+          line_plot = plotting.line(
+               labels=df["labels"],
+               series=df["series"],
+               title="Foreign Investor Shareholding Ratio",
+               yaxis_color="blue",
+               y_axis_name="",
+          )
+          return line_plot
+
+     ```
+     
+!!! info "Shareholding Distribution Table, Pie Chart"
+     ```python
+     def pie(data_loader: DataLoader, stock_id: str, start_date: str, end_date: str):
+          df = data_loader.taiwan_stock_holding_shares_per(
+               stock_id=stock_id, start_date=start_date, end_date=end_date
+          )
+          df = df[df["date"] == max(df["date"])]
+          df = df[df["HoldingSharesLevel"] != "total"]
+          df["labels"] = df["HoldingSharesLevel"]
+          df["series"] = df["percent"]
+          pie_plot = plotting.pie(
+               labels=df["labels"], series=df["series"], title="Shareholding Distribution Table"
+          )
+          return pie_plot
+
+     ```
+     
+!!! info "Combine into a dashboard"
+     ```python
+     def dashboard(stock_id: str, start_date: str, end_date: str):
+          data_loader = DataLoader()
+          page = Page(layout=Page.SimplePageLayout)
+          page.add(
+               kline(data_loader, stock_id, start_date, end_date),
+               bar(data_loader, stock_id, start_date, end_date),
+               line(data_loader, stock_id, start_date, end_date),
+               pie(data_loader, stock_id, start_date, end_date),
+          )
+          dashboard_html_path = str(PATH.joinpath("dashboard.html"))
+          post_html_path = str(PATH.joinpath("post.html"))
+          page.render(dashboard_html_path)
+          post_html = open(post_html_path, "r", encoding="utf-8").read()
+          dashboard_html = open(dashboard_html_path, "r", encoding="utf-8").read()
+          html = post_html.replace("DASHBOARD", dashboard_html)
+          with open(dashboard_html_path, "w", encoding="utf-8") as e:
+               e.write(html)
+
+     ```
+     
+!!! info "Run the web server with Flask"
+     ```python
+     app = Flask(__name__, template_folder=str(PATH))
+
+
+     @app.route("/", methods=["GET", "POST"])
+     def submit():
+          if request.method == "POST":
+               stock_id = request.form.get("stock_id")
+               start_date = request.form.get("start_date")
+               end_date = request.form.get("end_date")
+               logger.info(stock_id)
+               dashboard(stock_id=stock_id, start_date=start_date, end_date=end_date)
+               return render_template("dashboard.html")
+          return render_template("post.html")
+
+
+     app.run(host="0.0.0.0", debug=True)
+
+     ```

--- a/docs/tutor/analysis/Kline.en.md
+++ b/docs/tutor/analysis/Kline.en.md
@@ -1,0 +1,28 @@
+#### [kbar_plotting.ipynb](https://colab.research.google.com/drive/1u1cJGFNCLOeBIR0PdeKlsqgKBJSvJg_y?usp=sharing)
+
+![gif](https://finmind.github.io/images/kbar_plotting.gif)
+
+!!! info "Plot K-Line"
+     ```python
+     # Get stock prices
+     from FinMind.data import DataLoader
+
+     dl = DataLoader()
+     # Download Taiwan stock price data
+     stock_data = dl.taiwan_stock_daily(
+     stock_id='2609', start_date='2018-01-01', end_date='2021-06-26'
+     )
+     # Download data of the three major institutional investors
+     stock_data = dl.feature.add_kline_institutional_investors(
+     stock_data
+     ) 
+     # Download margin purchase / short sale data
+     stock_data = dl.feature.add_kline_margin_purchase_short_sale(
+     stock_data
+     )
+
+     # Plot the K-line chart
+     from FinMind import plotting
+
+     plotting.kline(stock_data)
+     ```

--- a/docs/tutor/analysis/SnapshotTreemap.en.md
+++ b/docs/tutor/analysis/SnapshotTreemap.en.md
@@ -1,0 +1,25 @@
+## Expected execution result is shown below (HTML syntax has been added at line 136 of the code so the page auto-refreshes)
+
+![gif](https://finmind.github.io/images/snapshot_treemap.gif)
+
+## How to run?
+* Save the following code as `FinMind_tree_map_flask.py`
+* Install the package
+
+```python
+pip install apscheduler plotly FinMind -q
+```
+
+* Run the following command (replace `your_token` with your own token)
+
+```python
+FINMIND_API_TOKEN=your_token python FinMind_tree_map_flask.py
+```
+
+
+## The code is as follows
+<script src="https://gist.github.com/linsamtw/af68df2690b01469f3a0a726e67aff39.js"></script>
+
+## REF
+[medium](https://medium.com/finmind/python-%E5%8D%B3%E6%99%82%E8%B3%87%E6%96%99-pipeline-%E4%BB%A5%E7%89%88%E5%A1%8A%E5%9C%96x%E5%8D%B3%E6%99%82%E8%82%A1%E5%B8%82%E8%B3%87%E6%96%99%E7%82%BA%E4%BE%8B-a55de908dd5b)
+

--- a/docs/update_token.en.md
+++ b/docs/update_token.en.md
@@ -1,0 +1,19 @@
+# Update Token
+
+If you suspect your token has leaked, you can rotate it yourself on the [user info page](https://finmindtrade.com/analysis/#/account/user) — no need to contact support.
+
+#### How to use
+
+1. Open the [user info page](https://finmindtrade.com/analysis/#/account/user)
+2. Click the "Update Token" button below the `api token` field
+3. Confirm — a new token is generated immediately
+
+#### Behavior
+
+- Generates a new token in one click
+- Old token is invalidated immediately
+- All devices are signed out and must log in again to obtain the new token
+- Self-service — no support ticket required
+
+!!! tip
+    Rotate your token regularly to keep your account secure.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,12 +1,12 @@
 site_name: FinMind
-site_url: https://finmind.github.io/FinMindDoc/
+site_url: https://finmind.github.io/
 site_author: 'Sam'
 
 copyright: 'Copyright'
 
 theme:
     name: material
-    language: 'en'
+    language: 'zh-TW'
     features:
         - content.code.copy
         - content.tabs.link
@@ -101,4 +101,58 @@ plugins:
             - en
             - ja
         separator: '[\s\-\.]+'
-
+    - i18n:
+        docs_structure: suffix
+        fallback_to_default: true
+        reconfigure_material: true
+        reconfigure_search: true
+        languages:
+            - locale: zh
+              default: true
+              name: 中文
+              build: true
+              site_name: FinMind
+              theme:
+                language: zh-TW
+            - locale: en
+              name: English
+              build: true
+              site_name: FinMind
+              theme:
+                language: en
+              nav_translations:
+                總覽: Overview
+                快速開始: Quick Start
+                登入: Login
+                登入說明: Login Guide
+                更新 Token: Update Token
+                API 使用次數: API Usage Count
+                資料集: Datasets
+                台灣市場: Taiwan Market
+                技術面: Technical
+                籌碼面: Chip (Institutional)
+                基本面: Fundamental
+                衍生性金融商品: Derivative
+                即時資料: Real-Time
+                可轉債: Convertible Bond
+                其他: Others
+                美國市場: US Market
+                英國市場: UK Market
+                歐洲市場: Europe Market
+                日本市場: Japan Market
+                匯率: Exchange Rate
+                央行利率: Central Bank Interest Rate
+                原物料市場: Commodities
+                美國國債: US Government Bonds Yield
+                量化工具: Analysis Tools
+                回測: Backtesting
+                回測(引用外部 data): Backtesting (External Data)
+                K 線: K-Line
+                客製化看盤儀表板: Custom Dashboard
+                即時股市資訊 X 板塊圖: Snapshot Treemap
+                壓力測試: Stress Test
+                IP 封鎖政策: IP Ban Policy
+                聯絡我們: Contact Us
+                使用條款: License
+                贊助我們: Donate
+                官方網站: Official Website

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,5 @@ dependencies = [
     "pymdown-extensions>=10.14",
     "requests>=2.31",
     "mkdocs==1.5.3",
+    "mkdocs-static-i18n>=1.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -154,6 +154,7 @@ dependencies = [
     { name = "markdown-include" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
+    { name = "mkdocs-static-i18n" },
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
@@ -163,6 +164,7 @@ requires-dist = [
     { name = "markdown-include", specifier = "==0.8.1" },
     { name = "mkdocs", specifier = "==1.5.3" },
     { name = "mkdocs-material", specifier = ">=9.0,<10" },
+    { name = "mkdocs-static-i18n", specifier = ">=1.2" },
     { name = "pymdown-extensions", specifier = ">=10.14" },
     { name = "requests", specifier = ">=2.31" },
 ]
@@ -368,6 +370,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocs-static-i18n"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f9/51e2ffda9c7210bc35a24f3717b08c052cd4b728dfa87f901c00d8005259/mkdocs_static_i18n-1.3.1.tar.gz", hash = "sha256:a6125ea7db6cc1a900d76a967f262535af09831160a93c56d7f0d522a79b5faf", size = 1371325, upload-time = "2026-02-20T10:42:41.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/0b/43ff4afb6b438d47718b1959a22075ed95d8460d8c47381878b37a40de63/mkdocs_static_i18n-1.3.1-py3-none-any.whl", hash = "sha256:4036e24795a150c9c4d4b001ed24a43aec01335f76188dbe5a5d8fb4a27eba65", size = 21853, upload-time = "2026-02-20T10:42:40.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
透過 mkdocs-static-i18n plugin 建立中英雙語站，中文為預設語言（/）、英文於 /en/ 子路徑。新增 39 個 .en.md 對應檔，nav 標籤翻譯透過 plugin nav_translations 設定，並修正 site_url 至實際發佈根網域以讓語言切換器正確跳轉。