### PR TITLE
docs: 註明月營收/三大法人/三大財報涵蓋興櫃

### DIFF
--- a/docs/WhatIsNew.en.md
+++ b/docs/WhatIsNew.en.md
@@ -1,3 +1,11 @@
+#### 2026-05-19
+* The following datasets now cover **emerging market companies** in addition to TWSE-listed and TPEx OTC companies (distinguished by `stock_id`; use `TaiwanStockInfo` to look up market type):
+    * [Monthly Revenue Table TaiwanStockMonthRevenue](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockmonthrevenue)
+    * [Income Statement TaiwanStockFinancialStatements](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockfinancialstatements)
+    * [Balance Sheet TaiwanStockBalanceSheet](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockbalancesheet)
+    * [Cash Flows Statement TaiwanStockCashFlowsStatement](https://finmind.github.io/en/tutor/TaiwanMarket/Fundamental/#taiwanstockcashflowsstatement)
+    * [Institutional Investors Buy/Sell TaiwanStockInstitutionalInvestorsBuySell](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockinstitutionalinvestorsbuysell)
+
 #### 2026-05-06
 * [Taiwan Stock Trading Daily Report by Branch TaiwanStockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/) storage_objects docs: added a FinMind package example (`taiwan_stock_trading_daily_report(use_object=True)`).
 

--- a/docs/WhatIsNew.md
+++ b/docs/WhatIsNew.md
@@ -1,3 +1,11 @@
+#### 2026-05-19
+* 以下資料集新增**興櫃 (Emerging)** 公司涵蓋（以 `stock_id` 區分上市/上櫃/興櫃，可搭配 `TaiwanStockInfo` 查詢市場別）：
+    * [月營收表 TaiwanStockMonthRevenue](https://finmind.github.io/tutor/TaiwanMarket/Fundamental/#taiwanstockmonthrevenue)
+    * [綜合損益表 TaiwanStockFinancialStatements](https://finmind.github.io/tutor/TaiwanMarket/Fundamental/#taiwanstockfinancialstatements)
+    * [資產負債表 TaiwanStockBalanceSheet](https://finmind.github.io/tutor/TaiwanMarket/Fundamental/#taiwanstockbalancesheet)
+    * [現金流量表 TaiwanStockCashFlowsStatement](https://finmind.github.io/tutor/TaiwanMarket/Fundamental/#taiwanstockcashflowsstatement)
+    * [個股三大法人買賣表 TaiwanStockInstitutionalInvestorsBuySell](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockinstitutionalinvestorsbuysell)
+
 #### 2026-05-06
 * [台股分點資料表 TaiwanStockTradingDailyReport](https://finmind.github.io/tutor/TaiwanMarket/Chip/) storage_objects 文件補上 FinMind package 範例 (`taiwan_stock_trading_daily_report(use_object=True)`)
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -296,6 +296,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 ### TaiwanStockInstitutionalInvestorsBuySell (個股三大法人買賣表)
 - Tier: Free (with data_id) / Backer/Sponsor (all stocks by start_date only)
 - Data range: 2005-01-01 ~ now
+- Coverage: 上市 (TWSE), 上櫃 (TPEx), 興櫃 (Emerging) 三市場，以 stock_id 區分
 - Update: Mon-Fri 20:00
 - Params: dataset=TaiwanStockInstitutionalInvestorsBuySell, data_id=2330, start_date=2020-04-01, end_date=2020-04-12
 - Params (all stocks, Backer/Sponsor): dataset=TaiwanStockInstitutionalInvestorsBuySell, start_date=2020-04-01 (不帶 data_id，取得該日所有股票資料)
@@ -427,6 +428,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 ### TaiwanStockFinancialStatements (綜合損益表)
 - Tier: Free (with data_id) / Backer/Sponsor (all stocks by start_date only)
 - Data range: 1990-03-01 ~ now
+- Coverage: 上市 (TWSE), 上櫃 (TPEx), 興櫃 (Emerging) 三市場，以 stock_id 區分
 - Params: dataset=TaiwanStockFinancialStatements, data_id=2330, start_date=2019-01-01
 - Params (all stocks, Backer/Sponsor): dataset=TaiwanStockFinancialStatements, start_date=2019-01-01 (不帶 data_id，取得該日所有股票資料)
 - Columns: date (str), stock_id (str), type (str), value (float64), origin_name (str)
@@ -434,6 +436,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 ### TaiwanStockBalanceSheet (資產負債表)
 - Tier: Free (with data_id) / Backer/Sponsor (all stocks by start_date only)
 - Data range: 2011-12-01 ~ now
+- Coverage: 上市 (TWSE), 上櫃 (TPEx), 興櫃 (Emerging) 三市場，以 stock_id 區分
 - Params: dataset=TaiwanStockBalanceSheet, data_id=2330, start_date=2019-03-31
 - Params (all stocks, Backer/Sponsor): dataset=TaiwanStockBalanceSheet, start_date=2019-03-31 (不帶 data_id，取得該日所有股票資料)
 - Columns: date (str), stock_id (str), type (str), value (float64), origin_name (str)
@@ -441,6 +444,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 ### TaiwanStockCashFlowsStatement (現金流量表)
 - Tier: Free (with data_id) / Backer/Sponsor (all stocks by start_date only)
 - Data range: 2008-06-01 ~ now
+- Coverage: 上市 (TWSE), 上櫃 (TPEx), 興櫃 (Emerging) 三市場，以 stock_id 區分
 - Params: dataset=TaiwanStockCashFlowsStatement, data_id=2330, start_date=2019-03-31
 - Params (all stocks, Backer/Sponsor): dataset=TaiwanStockCashFlowsStatement, start_date=2019-03-31 (不帶 data_id，取得該日所有股票資料)
 - Columns: date (str), stock_id (str), type (str), value (float64), origin_name (str)
@@ -462,6 +466,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 ### TaiwanStockMonthRevenue (月營收表)
 - Tier: Free (with data_id) / Backer/Sponsor (all stocks by start_date only)
 - Data range: 2002-02-01 ~ now
+- Coverage: 上市 (TWSE), 上櫃 (TPEx), 興櫃 (Emerging) 三市場，以 stock_id 區分
 - Params: dataset=TaiwanStockMonthRevenue, data_id=2330, start_date=2019-03-31
 - Params (all stocks, Backer/Sponsor): dataset=TaiwanStockMonthRevenue, start_date=2019-03-31 (不帶 data_id，取得該日所有股票資料)
 - Columns: date (str), stock_id (str), country (str), revenue (int64), revenue_month (int64), revenue_year (int64)

--- a/docs/tutor/TaiwanMarket/Chip.en.md
+++ b/docs/tutor/TaiwanMarket/Chip.en.md
@@ -306,6 +306,7 @@ In Taiwan stock chip data, we have 20 datasets as follows:
 #### Institutional Investors Buy/Sell TaiwanStockInstitutionalInvestorsBuySell
 
 - Data range: 2005-01-01 ~ now
+- Coverage: listed (TWSE), OTC (TPEx) and emerging market companies, distinguished by `stock_id` (use `TaiwanStockInfo` to look up market type)
 - Data update time **Monday to Friday 20:00**, the actual update time is based on the API data.
 
 !!! example

--- a/docs/tutor/TaiwanMarket/Chip.md
+++ b/docs/tutor/TaiwanMarket/Chip.md
@@ -306,6 +306,7 @@
 #### 法人買賣表 TaiwanStockInstitutionalInvestorsBuySell
 
 - 資料區間：2005-01-01 ~ now
+- 資料涵蓋：上市、上櫃、興櫃公司，以 `stock_id` 區分（可搭配 `TaiwanStockInfo` 查詢市場別）
 - 資料更新時間 **星期一至五 20:00**，實際更新時間以 API 資料為主
 
 !!! example

--- a/docs/tutor/TaiwanMarket/Fundamental.en.md
+++ b/docs/tutor/TaiwanMarket/Fundamental.en.md
@@ -18,6 +18,7 @@ In Taiwan stock fundamental data, we have 12 datasets, as follows:
 #### Income Statement TaiwanStockFinancialStatements
 
 - Data range: 1990-03-01 ~ now
+- Coverage: listed (TWSE), OTC (TPEx) and emerging market companies, distinguished by `stock_id` (use `TaiwanStockInfo` to look up market type)
 
 !!! example
     === "Package"
@@ -190,6 +191,7 @@ In Taiwan stock fundamental data, we have 12 datasets, as follows:
 #### Balance Sheet TaiwanStockBalanceSheet
 
 - Data range: 2011-12-01 ~ now
+- Coverage: listed (TWSE), OTC (TPEx) and emerging market companies, distinguished by `stock_id` (use `TaiwanStockInfo` to look up market type)
 
 !!! example
     === "Package"
@@ -361,6 +363,7 @@ In Taiwan stock fundamental data, we have 12 datasets, as follows:
 #### Cash Flows Statement TaiwanStockCashFlowsStatement
 
 - Data range: 2008-06-01 ~ now
+- Coverage: listed (TWSE), OTC (TPEx) and emerging market companies, distinguished by `stock_id` (use `TaiwanStockInfo` to look up market type)
 
 !!! example
     === "Package"
@@ -919,6 +922,7 @@ In Taiwan stock fundamental data, we have 12 datasets, as follows:
 #### Monthly Revenue Table TaiwanStockMonthRevenue
 
 - Data range: 2002-02-01 ~ now
+- Coverage: listed (TWSE), OTC (TPEx) and emerging market companies, distinguished by `stock_id` (use `TaiwanStockInfo` to look up market type)
 
 !!! example
     === "Package"

--- a/docs/tutor/TaiwanMarket/Fundamental.md
+++ b/docs/tutor/TaiwanMarket/Fundamental.md
@@ -18,6 +18,7 @@
 #### 綜合損益表 TaiwanStockFinancialStatements
 
 - 資料區間：1990-03-01 ~ now
+- 資料涵蓋：上市、上櫃、興櫃公司，以 `stock_id` 區分（可搭配 `TaiwanStockInfo` 查詢市場別）
 
 !!! example
     === "Package"
@@ -190,6 +191,7 @@
 #### 資產負債表 TaiwanStockBalanceSheet
 
 - 資料區間：2011-12-01 ~ now
+- 資料涵蓋：上市、上櫃、興櫃公司，以 `stock_id` 區分（可搭配 `TaiwanStockInfo` 查詢市場別）
 
 !!! example
     === "Package"
@@ -361,6 +363,7 @@
 #### 現金流量表 TaiwanStockCashFlowsStatement
 
 - 資料區間：2008-06-01 ~ now
+- 資料涵蓋：上市、上櫃、興櫃公司，以 `stock_id` 區分（可搭配 `TaiwanStockInfo` 查詢市場別）
 
 !!! example
     === "Package"
@@ -919,6 +922,7 @@
 #### 月營收表 TaiwanStockMonthRevenue
 
 - 資料區間：2002-02-01 ~ now
+- 資料涵蓋：上市、上櫃、興櫃公司，以 `stock_id` 區分（可搭配 `TaiwanStockInfo` 查詢市場別）
 
 !!! example
     === "Package"


### PR DESCRIPTION
## Summary
- 在以下 5 個資料集章節新增一行涵蓋說明（同時涵蓋上市、上櫃、興櫃公司，以 `stock_id` 區分；可搭配 `TaiwanStockInfo` 查詢市場別）
- 同步更新 `llms-full.txt`（公開給 AI agent 的對外文件）與 `WhatIsNew`，中英版本一併補
- 對外行為僅是「文件補上既有涵蓋範圍」，無新增 dataset、無 schema/endpoint/會員等級變更

涵蓋的資料集：

- 月營收表 TaiwanStockMonthRevenue
- 綜合損益表 TaiwanStockFinancialStatements
- 資產負債表 TaiwanStockBalanceSheet
- 現金流量表 TaiwanStockCashFlowsStatement
- 個股三大法人買賣表 TaiwanStockInstitutionalInvestorsBuySell

## Test plan
- [ ] 預覽 mkdocs：5 個 dataset 章節各自首段都看得到「資料涵蓋：上市、上櫃、興櫃」說明行
- [ ] `WhatIsNew.md` / `WhatIsNew.en.md` 最上方為 2026-05-19 條目
- [ ] `llms-full.txt` 5 個 dataset 區塊都新增 `- Coverage:` 行
- [ ] 連結 anchor (`#taiwanstockmonthrevenue` 等) 可點

🤖 Generated with [Claude Code](https://claude.com/claude-code)