### PR TITLE
docs: WhatsNew 補登服務狀態頁（中英）+ mkdocs.yml 整理

### DIFF
--- a/docs/WhatIsNew.en.md
+++ b/docs/WhatIsNew.en.md
@@ -1,3 +1,6 @@
+#### 2026-06-03
+* Added [Service Status & Uptime](https://finmind.github.io/en/ServiceStatus/): a public, real-time status page at [status.finmindtrade.com](https://status.finmindtrade.com), explaining how API uptime is calculated and the status tiers (Operational / Degraded Performance / Partial Outage / Major Outage), which serve as the basis for the enterprise-plan SLA.
+
 #### 2026-05-23
 * Added [Taiwan Stock Index Codes](https://finmind.github.io/en/tutor/TaiwanMarket/IndexCodes/): [taiwan_stock_tick_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan_stock_tick_snapshot-sponsor) `data_id` also accepts 91 three-digit index codes in addition to 4-digit stock IDs (e.g. `001` = TAIEX, `101` = OTC weighted), grouped into broad market / sector / themed (Smart Beta) / leverage & inverse categories.
 

--- a/docs/WhatIsNew.md
+++ b/docs/WhatIsNew.md
@@ -1,3 +1,6 @@
+#### 2026-06-03
+* 新增 [服務狀態與可用率 ServiceStatus](https://finmind.github.io/ServiceStatus/) 頁面：提供公開即時狀態頁 [status.finmindtrade.com](https://status.finmindtrade.com)，說明 API 可用率 (uptime) 的計算方式與狀態分級（Operational / Degraded Performance / Partial Outage / Major Outage），作為企業方案 SLA 的衡量基準
+
 #### 2026-05-23
 * 新增 [台股指數代號對照表 IndexCodes](https://finmind.github.io/tutor/TaiwanMarket/IndexCodes/)：[台股即時資訊 taiwan_stock_tick_snapshot](https://finmind.github.io/tutor/TaiwanMarket/RealTime/#taiwan_stock_tick_snapshot-sponsor) 的 `data_id` 除 4 碼個股代號外，亦支援 91 個 3 碼指數代號（例 `001` 加權指數、`101` 櫃買加權），完整對照分為大盤 / 產業 / 主題 Smart Beta / 槓桿反向 五組
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,26 +1,56 @@
+# ============================================================
+#  Site
+# ============================================================
 site_name: FinMind
 site_url: https://finmind.github.io/
 site_author: 'Sam'
-
 copyright: 'Copyright'
 
-theme:
-    name: material
-    language: 'zh-TW'
-    features:
-        - content.code.copy
-        - content.tabs.link
-        - navigation.top
-        - search.highlight
-
+# ============================================================
+#  Repository
+# ============================================================
 repo_name: FinMind/FinMind
 repo_url: https://github.com/FinMind/FinMind
 
-extra:
-  analytics:
-    provider: google
-    property: G-N2YPL1PVLE
+# ============================================================
+#  Theme
+# ============================================================
+theme:
+    name: material
+    language: 'zh-TW'
+    font:
+        text: Noto Sans TC   # 繁中友善（取代預設 Roboto）
+        code: JetBrains Mono
+    features:
+        - navigation.tracking
+        - navigation.top
+        - navigation.footer
+        - toc.follow
+        - content.code.copy
+        - content.code.annotate
+        - content.tabs.link
+        - search.highlight
+        - search.suggest
+        - search.share
+    icon:
+        repo: fontawesome/brands/github
 
+# ============================================================
+#  Extra（分析 + 社群）
+# ============================================================
+extra:
+    analytics:
+        provider: google
+        property: G-N2YPL1PVLE
+    social:
+        - icon: fontawesome/brands/github
+          link: https://github.com/FinMind/FinMind
+        - icon: fontawesome/solid/globe
+          link: https://finmindtrade.com/
+
+# ============================================================
+#  Navigation
+# ============================================================
 nav:
     - 總覽: 'index.md'
     - 快速開始: "quickstart.md"
@@ -64,20 +94,22 @@ nav:
         - K 線: "tutor/analysis/Kline.md"
         - 客製化看盤儀表板: "tutor/analysis/CustomerDashboardWebServer.md"
         - 即時股市資訊 X 板塊圖: "tutor/analysis/SnapshotTreemap.md"
-    - Versions:
-        - What's New: "WhatIsNew.md"
-        - Release Note: "release.md"
-        - v4 (Latest): https://finmind.github.io/
-        - v3: https://finmind.github.io/v3" target="_blank
-    - 服務狀態與可用率: "ServiceStatus.md"
-    - 壓力測試: "StressTest.md"
-    - IP 封鎖政策: "BanIPPolicy.md"
-    - 聯絡我們: "Contact.md"
-    - 使用條款: "License.md"
-    - 隱私權政策: "PrivacyPolicy.md"
-    - 贊助我們: "Donate.md"
-    - 官方網站: https://finmindtrade.com/" target="_blank
+    - 更新公告: "WhatIsNew.md"
+    - 版本紀錄: "release.md"
+    - 服務與政策:
+        - 服務狀態與可用率: "ServiceStatus.md"
+        - 壓力測試: "StressTest.md"
+        - IP 封鎖政策: "BanIPPolicy.md"
+    - 關於:
+        - 聯絡我們: "Contact.md"
+        - 使用條款: "License.md"
+        - 隱私權政策: "PrivacyPolicy.md"
+        - 贊助我們: "Donate.md"
+        - 官方網站: https://finmindtrade.com/
 
+# ============================================================
+#  Markdown extensions
+# ============================================================
 markdown_extensions:
     - toc:
         permalink: true
@@ -85,6 +117,8 @@ markdown_extensions:
         base_path: docs
     - markdown.extensions.meta:
     - admonition
+    - attr_list          # 連結/元素屬性（例如外連開新分頁）
+    - md_in_html
     - pymdownx.highlight:
         anchor_linenums: true
     - pymdownx.inlinehilite:
@@ -99,6 +133,9 @@ markdown_extensions:
               class: mermaid
               format: !!python/name:pymdownx.superfences.fence_code_format
 
+# ============================================================
+#  Plugins（搜尋 + i18n 雙語）
+# ============================================================
 plugins:
     - search:
         lang:
@@ -155,6 +192,10 @@ plugins:
                 K 線: K-Line
                 客製化看盤儀表板: Custom Dashboard
                 即時股市資訊 X 板塊圖: Snapshot Treemap
+                更新公告: What's New
+                版本紀錄: Release Note
+                服務與政策: Service & Policy
+                關於: About
                 服務狀態與可用率: Service Status & Uptime
                 壓力測試: Stress Test
                 IP 封鎖政策: IP Ban Policy


### PR DESCRIPTION
## 摘要
延續服務狀態頁（已 merged #127）的收尾，補上 What's New 條目並整理 mkdocs.yml。

## WhatIsNew（中英一致）
- `WhatIsNew.md` / `WhatIsNew.en.md` 新增 2026-06-03 條目：新增「服務狀態與可用率 ServiceStatus」頁（公開狀態頁 status.finmindtrade.com、可用率計算與狀態分級、企業方案 SLA 衡量基準）

## mkdocs.yml 整理
- 修正壞掉的外連寫法（v3 / 官方網站末端殘留畸形的 `" target="_blank`；Material 本就自動開新分頁）
- 移除 `Versions` 群組：What's New / Release Note 提到最外層並改中文名（**更新公告** / **版本紀錄**）；一併移除 v4(Latest)、v3 版本連結
- 最外層 nav 過長 → 雜項收進「**服務與政策**」「**關於**」兩個下拉群組
- 統一縮排 + 加分區註解
- theme：字體改 Noto Sans TC / JetBrains Mono（CJK 友善）、補 navigation/search/code 等功能與社群連結；**維持 Material 預設配色（未改顏色）**
- markdown_extensions：新增 `attr_list` / `md_in_html`

## 驗證
- `mkdocs build` 通過（zh + en 雙語），無 nav/config 錯誤或相容性警告
- 中英 WhatIsNew 內文皆含新條目；英文 nav 標籤翻譯到位（Service & Policy / About 等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)