### PR TITLE
docs(WhatsNew): Python 3.12 支援與升級須知

### DIFF
--- a/docs/WhatIsNew.en.md
+++ b/docs/WhatIsNew.en.md
@@ -1,3 +1,8 @@
+#### 2026-06-13
+* The FinMind Python package now supports **Python 3.12** (Python 3.8–3.11 remain supported). Starting from this release, dependencies are upgraded to `pandas>=2.0` and `ta>=0.11` (`numpy` and `pydantic` unchanged).
+    * **No code changes are required** to call FinMind: the public `DataLoader`, strategy, and plotting interfaces are unchanged.
+    * :warning: **Upgrade note**: installing/upgrading also bumps `pandas` to 2.x and `ta` to 0.11 in your environment. If your **own surrounding code** still uses pandas 1.x APIs removed in 2.0, you will need to adjust it — common examples: `df.append()` → `pd.concat([...])`, `df.to_dict("r")` → `df.to_dict("records")`, `df.iteritems()` → `df.items()`. If you cannot adjust yet, pin an older FinMind version for now.
+
 #### 2026-06-09
 * Added [Futures Spread Tick Table TaiwanFuturesSpreadTick](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesspreadtick-sponsor) (sponsor members only): per-trade futures spread (near/far month) data, including contract months, deal time, spread deal price, volume, near month price, far month price, and spread-to-spread deal flag. Only one day of data is provided per request; data accumulates daily since 2026-04-27 (earlier historical backfill not yet included).
 

--- a/docs/WhatIsNew.md
+++ b/docs/WhatIsNew.md
@@ -1,3 +1,8 @@
+#### 2026-06-13
+* FinMind Python 套件新增支援 **Python 3.12**（持續支援 Python 3.8–3.11）。本版起套件相依升級為 `pandas>=2.0`、`ta>=0.11`（`numpy`、`pydantic` 維持不變）。
+    * 呼叫 FinMind 的程式碼**無需修改**：`DataLoader`、策略 (Strategy)、繪圖等對外介面皆不變。
+    * :warning: **升級須知**：安裝／升級會一併將環境中的 `pandas` 升至 2.x、`ta` 升至 0.11。若你**其餘自有程式碼**仍使用 pandas 1.x 在 2.0 已移除的寫法，需自行調整，常見如：`df.append()` → `pd.concat([...])`、`df.to_dict("r")` → `df.to_dict("records")`、`df.iteritems()` → `df.items()`。若暫時無法調整，可先固定安裝舊版 FinMind。
+
 #### 2026-06-09
 * 新增 [期貨價差每筆成交資料 TaiwanFuturesSpreadTick](https://finmind.github.io/tutor/TaiwanMarket/Derivative/#taiwanfuturesspreadtick-sponsor)（只限 sponsor 會員）：提供期貨價差（近月/遠月）每筆成交，含到期月份、成交時間、價差成交價、成交量、近月價格、遠月價格、是否價差對價差成交；單次請求只提供一天資料，資料自 2026-04-27 起逐交易日累積（暫不含更早歷史回補）
 


### PR DESCRIPTION
## 內容

更新公告（更新公告 / What's New）中英文版各新增一則 `2026-06-13` 條目，宣告 FinMind Python 套件支援 **Python 3.12**，並加上**升級須知**。

- 新增支援 Python 3.12（持續支援 3.8–3.11）
- 本版起相依升級為 `pandas>=2.0`、`ta>=0.11`（`numpy`/`pydantic` 不變）
- 明確說明：**呼叫 FinMind 的程式碼無需修改**（`DataLoader`/策略/繪圖介面不變）
- 升級須知：安裝/升級會連帶把環境的 `pandas` 升到 2.x、`ta` 升到 0.11；提醒使用者自有程式碼若用了 pandas 1.x 已移除寫法需調整（`append`→`concat`、`to_dict("r")`→`to_dict("records")`、`iteritems`→`items`）

## 對應

FinMind 套件本身的修正在 FinMind/FinMind#420。

🤖 Generated with [Claude Code](https://claude.com/claude-code)