### PR TITLE
docs: TaiwanStockWarrantTradingDailyReport 加入 storage_objects 整日下載

### DIFF
--- a/docs/WhatIsNew.en.md
+++ b/docs/WhatIsNew.en.md
@@ -1,3 +1,6 @@
+#### 2026-06-15
+* [Taiwan Stock Warrant Trading Daily Report TaiwanStockWarrantTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#query-by-taiwanstockwarranttradingdailyreport-sponsor) now supports storage_objects whole-day bulk download (sponsorpro members only); data is provided per trading day from feature launch, no historical backfill for now
+
 #### 2026-06-13
 * Added [Institutional Investors Buy/Sell (Wide) TaiwanStockInstitutionalInvestorsBuySellWide](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockinstitutionalinvestorsbuysellwide): same data as `TaiwanStockInstitutionalInvestorsBuySell` but in wide format — one row per trading day with each institutional investor's buy/sell as its own column, no manual pivot needed. Columns cover all historical investor categories; a category is 0 in eras where it did not exist (dealer split into proprietary/hedging from 2014-12-01; foreign dealer self from 2018-01-15). Data range 2005-01-01 ~ now
 * The FinMind Python package now supports **Python 3.12** (Python 3.8–3.11 remain supported). Starting from this release, dependencies are upgraded to `pandas>=2.0` and `ta>=0.11` (`numpy` and `pydantic` unchanged).

--- a/docs/WhatIsNew.md
+++ b/docs/WhatIsNew.md
@@ -1,3 +1,6 @@
+#### 2026-06-15
+* [台股權證分點資料表 TaiwanStockWarrantTradingDailyReport](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockwarranttradingdailyreport-sponsor) 新增 storage_objects 一次取得整日資料的下載方式（只限 sponsorpro 會員）；資料自本功能上線後逐交易日提供，暫不含歷史回補
+
 #### 2026-06-13
 * 新增 [個股三大法人買賣表（寬表）TaiwanStockInstitutionalInvestorsBuySellWide](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockinstitutionalinvestorsbuysellwide)：與 `TaiwanStockInstitutionalInvestorsBuySell` 相同資料，改為寬表（橫式），每個交易日一列、各法人別買賣攤平成獨立欄位（外資、外資自營商、投信、自營商及其自行買賣／避險），免自行轉置。欄位涵蓋所有歷史法人別分類，尚未存在的年代該欄為 0（自營商於 2014-12-01 由合併拆為自行買賣／避險、外資自營商於 2018-01-15 起提供）；資料區間 2005-01-01 ~ now
 * FinMind Python 套件新增支援 **Python 3.12**（持續支援 Python 3.8–3.11）。本版起套件相依升級為 `pandas>=2.0`、`ta>=0.11`（`numpy`、`pydantic` 維持不變）。

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -382,6 +382,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - Params (by stock): dataset=TaiwanStockWarrantTradingDailyReport, data_id=084655, start_date=2023-06-21
 - Params (by broker): dataset=TaiwanStockWarrantTradingDailyReport, data_id=5920, start_date=2023-06-21
 - Columns: securities_trader, price, buy, sell, securities_trader_id, stock_id, date
+- Bulk download (sponsorpro): `GET /api/v4/storage_objects?dataset=TaiwanStockWarrantTradingDailyReport&date=2023-06-21` returns whole-day parquet via signed URL, ignores data_id / securities_trader_id. Python SDK: `api.taiwan_stock_warrant_trading_daily_report(date='2023-06-21', use_object=True)`.
 
 ### TaiwanstockGovernmentBankBuySell (台股八大行庫買賣表)
 - Tier: Sponsor

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,7 +15,7 @@
   - Some heavy datasets have dedicated endpoints instead of `/data` — they will return 422 if queried via `/data?dataset=...`. See `llms-full.txt` for the exact endpoint of each dataset. Currently:
     - `GET /taiwan_stock_trading_daily_report` (params: data_id or securities_trader_id, date) — TaiwanStockTradingDailyReport, single date per request
     - `GET /taiwan_stock_trading_daily_report_secid_agg` (params: data_id, start_date, end_date) — TaiwanStockTradingDailyReportSecIdAgg
-  - `GET /storage_objects` (params: dataset, date) — sponsorpro-tier whole-day parquet via signed URL, ignores data_id. Currently supports: TaiwanStockPriceTick, TaiwanStockTradingDailyReport, TaiwanStockKBar, TaiwanFuturesTick, TaiwanOptionTick.
+  - `GET /storage_objects` (params: dataset, date) — sponsorpro-tier whole-day parquet via signed URL, ignores data_id. Currently supports: TaiwanStockPriceTick, TaiwanStockTradingDailyReport, TaiwanStockWarrantTradingDailyReport, TaiwanStockKBar, TaiwanFuturesTick, TaiwanOptionTick.
 
 ## Python SDK
 

--- a/docs/tutor/TaiwanMarket/Chip.en.md
+++ b/docs/tutor/TaiwanMarket/Chip.en.md
@@ -2088,6 +2088,86 @@ In Taiwan stock chip data, we have 21 datasets as follows:
         }
         ```
 
+#### Fetch all warrant trading data for a specific date at once (available only to [sponsorpro](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+(Due to the large data volume, each request only provides one day's data.)
+
+- Data range: 2023-06-21 ~ now.
+- Providing the dataset and date parameters returns the branch-level trading data of all warrants for that day.
+- Downloads the whole-day parquet via a signed URL, avoiding file-by-file queries — suitable for batch analysis covering all warrants in the market.
+- Updated daily. The actual update time is based on the API data.
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_warrant_trading_daily_report(
+            date='2023-06-21',
+            use_object=True,
+        )
+        ```
+    === "Python-request"
+        ```python
+        import io
+        import requests
+        import pandas as pd
+
+        url = "https://api.finmindtrade.com/api/v4/storage_objects"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockWarrantTradingDailyReport",
+            "date": "2023-06-21",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = pd.read_parquet(io.BytesIO(resp.content))
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        library(arrow)
+
+        url = 'https://api.finmindtrade.com/api/v4/storage_objects'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockWarrantTradingDailyReport",
+                date= "2023-06-21"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        con = content(response, "raw")
+        data <- read_parquet(con)
+        close(con)
+        head(data)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | securities_trader   |   price |   buy |   sell |   securities_trader_id |   stock_id | date       |
+        |---:|:--------------------|--------:|------:|-------:|-----------------------:|-----------:|:-----------|
+        |  0 | 元富                |    2.48 |     0 |   4000 |                   5920 |     084655 | 2023-06-21 |
+        |  1 | 凱基                |    2.48 |  4000 |      0 |                   9200 |     084655 | 2023-06-21 |
+    === "Schema"
+        ```
+        {
+            securities_trader: str, # securities trader name
+            price: float64, # deal price
+            buy: int32, # shares bought
+            sell: int32, # shares sold
+            securities_trader_id: str, # securities trader code
+            stock_id: str, # stock symbol
+            date: str # date
+        }
+        ```
+
 ----------------------------------
 #### Taiwan Stock Government Bank Buy/Sell TaiwanStockGovernmentBankBuySell (only available for [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
 

--- a/docs/tutor/TaiwanMarket/Chip.md
+++ b/docs/tutor/TaiwanMarket/Chip.md
@@ -2088,6 +2088,86 @@
         }
         ```
 
+#### 一次拿特定日期，所有權證分點資料 (只限 [sponsorpro](https://finmindtrade.com/analysis/#/Sponsor/sponsor) 會員使用)
+(由於資料量過大，單次請求只提供一天資料)
+
+- 資料區間：2023-06-21 ~ now
+- 輸入 dataset、date 參數，會回傳 date 當天所有權證的分點資料
+- 透過 signed URL 下載整日 parquet，免逐檔查詢，適合需要全市場權證分點的批次分析
+- 每日更新，實際更新時間以 API 資料為主
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_warrant_trading_daily_report(
+            date='2023-06-21',
+            use_object=True,
+        )
+        ```
+    === "Python-request"
+        ```python
+        import io
+        import requests
+        import pandas as pd
+
+        url = "https://api.finmindtrade.com/api/v4/storage_objects"
+        token = "" # 參考登入，獲取金鑰
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockWarrantTradingDailyReport",
+            "date": "2023-06-21",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = pd.read_parquet(io.BytesIO(resp.content))
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        library(arrow)
+
+        url = 'https://api.finmindtrade.com/api/v4/storage_objects'
+        token = "" # 參考登入，獲取金鑰
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockWarrantTradingDailyReport",
+                date= "2023-06-21"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        con = content(response, "raw")
+        data <- read_parquet(con)
+        close(con)
+        head(data)
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | securities_trader   |   price |   buy |   sell |   securities_trader_id |   stock_id | date       |
+        |---:|:--------------------|--------:|------:|-------:|-----------------------:|-----------:|:-----------|
+        |  0 | 元富                |    2.48 |     0 |   4000 |                   5920 |     084655 | 2023-06-21 |
+        |  1 | 凱基                |    2.48 |  4000 |      0 |                   9200 |     084655 | 2023-06-21 |
+    === "Schema"
+        ```
+        {
+            securities_trader: str, # 券商名稱
+            price: float64, # 成交價
+            buy: int32, # 買進股數
+            sell: int32, # 賣出股數
+            securities_trader_id: str, # 券商代碼
+            stock_id: str, # 股票代碼
+            date: str # 日期
+        }
+        ```
+
 ----------------------------------
 #### 台股八大行庫買賣表 TaiwanStockGovernmentBankBuySell (只限 [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) 會員使用)
 


### PR DESCRIPTION
## 內容
權證分點資料表 `TaiwanStockWarrantTradingDailyReport` 納入 `/api/v4/storage_objects` 整日全市場 parquet 下載（sponsorpro），文件 mirror 既有 `TaiwanStockTradingDailyReport`。

- **Chip.md / Chip.en.md**：權證分點區塊後新增「一次拿特定日期，所有權證分點資料」storage_objects 範例（Package `use_object=True` / Python-request / R + 輸出 schema），資料區間 2023-06-21 ~ now
- **llms.txt**：storage_objects `Currently supports` 清單加入 warrant
- **llms-full.txt**：warrant 段落補 `Bulk download (sponsorpro)` 行
- **WhatIsNew.md / .en.md**：新增 2026-06-15 變更紀錄

## ⚠️ 先別 merge（gate）
prod 尚未產出 warrant storage parquet（依賴 financialdata generator + dataflow DAG 部署產檔）。**在那之前 merge → 使用者照文件下載會拿到 404／空檔。**
- 等 prod 有可用範例日期後再 merge。
- WhatIsNew 日期目前填 2026-06-15，merge 時若實際上線日不同請順手改成上線日。