### PR TITLE
docs(TaiwanStockInfoWithWarrantSummary): 新增上櫃(TPEX)權證標的對照涵蓋說明

### DIFF
--- a/docs/WhatIsNew.en.md
+++ b/docs/WhatIsNew.en.md
@@ -1,4 +1,5 @@
 #### 2026-06-15
+* [Taiwan Warrant Underlying Reference Table TaiwanStockInfoWithWarrantSummary](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrantsummary-sponsor) now covers **OTC (TPEX)** warrants' underlying (mother stock) reference in addition to listed (TWSE); OTC warrant underlying history goes back to 2011-01-03, so you can look up the warrants of a given underlying (including expired and code-reused historical warrants)
 * [Taiwan Stock Warrant Trading Daily Report TaiwanStockWarrantTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#query-by-taiwanstockwarranttradingdailyreport-sponsor) now supports storage_objects whole-day bulk download (sponsorpro members only); data is provided per trading day from feature launch, no historical backfill for now
 
 #### 2026-06-13

--- a/docs/WhatIsNew.md
+++ b/docs/WhatIsNew.md
@@ -1,4 +1,5 @@
 #### 2026-06-15
+* [台股權證標的對照表 TaiwanStockInfoWithWarrantSummary](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrantsummary-sponsor) 新增**上櫃 (TPEX)** 權證的標的（母股）對照涵蓋（原本僅上市 TWSE）；上櫃權證標的對照歷史回溯至 2011-01-03，可用母股代碼反查其對應權證（含已到期、代碼重用的歷史權證）
 * [台股權證分點資料表 TaiwanStockWarrantTradingDailyReport](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockwarranttradingdailyreport-sponsor) 新增 storage_objects 一次取得整日資料的下載方式（只限 sponsorpro 會員）；資料自本功能上線後逐交易日提供，暫不含歷史回補
 
 #### 2026-06-13

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -146,6 +146,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - Tier: Sponsor
 - Params: dataset=TaiwanStockInfoWithWarrantSummary, data_id=2330, start_date=2020-04-06
 - Columns: stock_id (str), date (str), close (float), target_stock_id (str), target_close (float), type (str), fulfillment_method (str), end_date (str), fulfillment_start_date (str), fulfillment_end_date (str), exercise_ratio (float), fulfillment_price (float)
+- Note: data_id is the underlying (mother stock) target_stock_id, not the warrant code; covers both listed (TWSE) and OTC (TPEX) warrants, OTC history back to 2011-01-03. Omit data_id to fetch the whole table and reverse-lookup a warrant's underlying.
 
 ### TaiwanStockTradingDate (台股交易日)
 - Tier: Free

--- a/docs/tutor/TaiwanMarket/Technical.en.md
+++ b/docs/tutor/TaiwanMarket/Technical.en.md
@@ -172,6 +172,7 @@ In Taiwan stock technical data, we have 20 datasets, as follows:
 #### Taiwan Warrant Underlying Reference Table TaiwanStockInfoWithWarrantSummary (available only to [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
 
 - Provides the warrant underlying reference table. (Since it includes warrant data, the data volume is large and takes about a minute.)
+- Covers both **listed (TWSE) and OTC (TPEX)** warrants' underlying (`target_stock_id`) reference; OTC warrant underlying history goes back to **2011-01-03**, so you can look up the warrants of a given underlying (including expired and code-reused historical warrants).
 - Data update time: **1:30 daily**. The actual update time is based on the API data.
 
 !!! example

--- a/docs/tutor/TaiwanMarket/Technical.md
+++ b/docs/tutor/TaiwanMarket/Technical.md
@@ -172,6 +172,7 @@
 #### 台股權證標的對照表 TaiwanStockInfoWithWarrantSummary(只限 [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) 使用)
 
 - 提供權證標的對照表。( 由於包含權證資料，資料量大，約需等一分鐘時間。 )
+- 涵蓋**上市 (TWSE) 與上櫃 (TPEX)** 權證的標的（母股 `target_stock_id`）對照；上櫃權證的標的對照歷史回溯至 **2011-01-03**，可用母股代碼反查其對應權證（含已到期、代碼重用的歷史權證）。
 - 資料更新時間 **每天 1:30**，實際更新時間以 API 資料為主
 
 !!! example


### PR DESCRIPTION
資料面已補上上櫃(TPEX)權證的標的(母股)對照(原本僅上市 TWSE),歷史回溯至 2011-01-03。更新對外文件讓使用者知道:

- **Technical.md / .en.md**: 資料集說明加註涵蓋上市+上櫃、上櫃歷史回溯 2011-01-03、可用母股反查對應權證(含已到期、代碼重用的歷史權證)。
- **WhatIsNew.md / .en.md**: 2026-06-15 新增一則公告。
- **llms-full.txt**: 補 AI-agent note(data_id=母股、上市+上櫃、不帶 data_id 反查)。

僅描述對外可見行為,不涉及內部實作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)