### PR TITLE
docs(AgentSkill): 新增 Windows (PowerShell) 安裝指令（可摺疊）

### DIFF
--- a/docs/tutor/AgentSkill.en.md
+++ b/docs/tutor/AgentSkill.en.md
@@ -33,6 +33,33 @@ There are two ways to use it — pick whichever fits:
         curl -o GEMINI.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
         ```
 
+??? note "🪟 Windows (PowerShell) install commands"
+    Windows 10/11 ships with `curl.exe` built in. Use the PowerShell versions below instead of the commands above (note the `.exe`: PowerShell's bare `curl` is an alias for `Invoke-WebRequest` and uses different syntax).
+    === "Claude Code"
+        ```powershell
+        mkdir $HOME\.claude\commands -Force
+        curl.exe -o $HOME\.claude\commands\finmind.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Codex"
+        ```powershell
+        curl.exe -o AGENTS.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Cursor"
+        ```powershell
+        mkdir .cursor\rules -Force
+        curl.exe -o .cursor\rules\finmind.mdc https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Windsurf"
+        ```powershell
+        curl.exe -o .windsurfrules https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Gemini"
+        ```powershell
+        curl.exe -o GEMINI.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+
+    > If you use **WSL** or **Git Bash**, the macOS / Linux commands above work as-is — no changes needed.
+
 ### Step 2: Set Up the Token
 
 Register at [FinMind](https://finmindtrade.com/analysis/#/account/register) and verify your email to obtain a token.
@@ -42,6 +69,16 @@ export FINMIND_TOKEN="your_token_here"
 ```
 
 We recommend adding this to `~/.bashrc` or `~/.zshrc` so it loads automatically every time you open a terminal.
+
+??? note "🪟 Windows (PowerShell) — set the Token"
+    PowerShell does not use `export`. Use this instead:
+
+    ```powershell
+    $env:FINMIND_TOKEN="your_token_here"   # current terminal only
+    setx FINMIND_TOKEN "your_token_here"   # persists (reopen the terminal to take effect)
+    ```
+
+    On **WSL** or **Git Bash**, `export` and `~/.bashrc` work the same as macOS / Linux.
 
 ### Step 3: Use It
 

--- a/docs/tutor/AgentSkill.en.md
+++ b/docs/tutor/AgentSkill.en.md
@@ -5,11 +5,16 @@ There are two ways to use it — pick whichever fits:
 1. **Agent Skill file (CLI tools)**: download the `/finmind` command file into Claude Code / Codex / Cursor / Windsurf / Gemini — see "Installation" below.
 2. **MCP Server**: tools that support [MCP](https://modelcontextprotocol.io/) (Claude Desktop / Claude Code, Cursor, Windsurf, Gemini CLI) can connect directly to the official FinMind MCP server — see "MCP Server".
 
-## Installation
+!!! abstract "On this page"
+    - [Installation](#install): [① Download](#download) · [② Token](#token) · [③ Use](#usage)
+    - [MCP Server](#mcp-server)
+    - [Examples](#examples)
 
-### Step 1: Download the Skill
+## Installation { #install }
 
-!!! example
+### Step 1: Download the Skill { #download }
+
+??? note "🍎 macOS / Linux install commands"
     === "Claude Code"
         ```bash
         mkdir -p ~/.claude/commands
@@ -60,15 +65,16 @@ There are two ways to use it — pick whichever fits:
 
     > If you use **WSL** or **Git Bash**, the macOS / Linux commands above work as-is — no changes needed.
 
-### Step 2: Set Up the Token
+### Step 2: Set Up the Token { #token }
 
 Register at [FinMind](https://finmindtrade.com/analysis/#/account/register) and verify your email to obtain a token.
 
-```bash
-export FINMIND_TOKEN="your_token_here"
-```
+??? note "🍎 macOS / Linux — set the Token"
+    ```bash
+    export FINMIND_TOKEN="your_token_here"
+    ```
 
-We recommend adding this to `~/.bashrc` or `~/.zshrc` so it loads automatically every time you open a terminal.
+    We recommend adding this to `~/.bashrc` or `~/.zshrc` so it loads automatically every time you open a terminal.
 
 ??? note "🪟 Windows (PowerShell) — set the Token"
     PowerShell does not use `export`. Use this instead:
@@ -80,7 +86,7 @@ We recommend adding this to `~/.bashrc` or `~/.zshrc` so it loads automatically 
 
     On **WSL** or **Git Bash**, `export` and `~/.bashrc` work the same as macOS / Linux.
 
-### Step 3: Use It
+### Step 3: Use It { #usage }
 
 In Claude Code, type `/finmind` followed by what you want to query:
 
@@ -121,7 +127,7 @@ After install, run `/reload-plugins` to connect and `/mcp` to verify. (The plugi
 
 For per-host config file locations, the `claude mcp add` / `gemini mcp add` / `codex mcp add` one-liners, and verification steps, see the [FinMind-MCP install guides](https://github.com/FinMind/FinMind-MCP/tree/master/install).
 
-## Examples
+## Examples { #examples }
 
 > The queries below work with both methods: with the **Skill file** prefix them with `/finmind`; with **MCP** just ask in natural language.
 

--- a/docs/tutor/AgentSkill.md
+++ b/docs/tutor/AgentSkill.md
@@ -5,11 +5,16 @@ FinMind 提供 AI Agent Skill，讓你可以在 [Gemini](https://gemini.google.c
 1. **Agent Skill 檔（CLI 工具）**：下載 `/finmind` 指令檔到 Claude Code / Codex / Cursor / Windsurf / Gemini，見下方「安裝」。
 2. **MCP Server**：支援 [MCP](https://modelcontextprotocol.io/) 的工具（Claude Desktop / Claude Code、Cursor、Windsurf、Gemini CLI）可直接連 FinMind 官方 MCP server，見「MCP Server」。
 
-## 安裝
+!!! abstract "本頁目錄"
+    - [安裝](#install)：[① 下載 Skill](#download) · [② 設定 Token](#token) · [③ 使用](#usage)
+    - [MCP Server](#mcp-server)
+    - [使用範例](#examples)
 
-### 步驟 1: 下載 Skill
+## 安裝 { #install }
 
-!!! example
+### 步驟 1: 下載 Skill { #download }
+
+??? note "🍎 macOS / Linux 安裝指令"
     === "Claude Code"
         ```bash
         mkdir -p ~/.claude/commands
@@ -60,15 +65,16 @@ FinMind 提供 AI Agent Skill，讓你可以在 [Gemini](https://gemini.google.c
 
     > 若你用 **WSL** 或 **Git Bash**，則上方 macOS / Linux 的指令可直接照用，不需改寫。
 
-### 步驟 2: 設定 Token
+### 步驟 2: 設定 Token { #token }
 
 至 [FinMind](https://finmindtrade.com/analysis/#/account/register) 註冊並驗證信箱後，取得 Token。
 
-```bash
-export FINMIND_TOKEN="your_token_here"
-```
+??? note "🍎 macOS / Linux 設定 Token"
+    ```bash
+    export FINMIND_TOKEN="your_token_here"
+    ```
 
-建議加到 `~/.bashrc` 或 `~/.zshrc`，這樣每次開終端都會自動載入。
+    建議加到 `~/.bashrc` 或 `~/.zshrc`，這樣每次開終端都會自動載入。
 
 ??? note "🪟 Windows（PowerShell）設定 Token"
     PowerShell 不用 `export`，請改用：
@@ -80,7 +86,7 @@ export FINMIND_TOKEN="your_token_here"
 
     用 **WSL** 或 **Git Bash** 的話，`export` 與 `~/.bashrc` 寫法與 macOS / Linux 相同。
 
-### 步驟 3: 使用
+### 步驟 3: 使用 { #usage }
 
 在 Claude Code 中輸入 `/finmind`，後面接你想查詢的內容：
 
@@ -121,7 +127,7 @@ export FINMIND_TOKEN="your_token_here"
 
 各 host 的設定檔位置、`claude mcp add` / `gemini mcp add` / `codex mcp add` 指令與驗證方式，詳見 [FinMind-MCP 安裝指南](https://github.com/FinMind/FinMind-MCP/tree/master/install)。
 
-## 範例
+## 範例 { #examples }
 
 > 以下查詢兩種方式都適用：**Skill 檔**需在前面加 `/finmind`；**MCP** 直接用自然語言提問即可。
 

--- a/docs/tutor/AgentSkill.md
+++ b/docs/tutor/AgentSkill.md
@@ -33,6 +33,33 @@ FinMind 提供 AI Agent Skill，讓你可以在 [Gemini](https://gemini.google.c
         curl -o GEMINI.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
         ```
 
+??? note "🪟 Windows（PowerShell）安裝指令"
+    Windows 10/11 已內建 `curl.exe`，請把上方指令改用下列 PowerShell 版本（注意要打 `curl.exe`，因為 PowerShell 的 `curl` 是 `Invoke-WebRequest` 的別名、語法不同）。
+    === "Claude Code"
+        ```powershell
+        mkdir $HOME\.claude\commands -Force
+        curl.exe -o $HOME\.claude\commands\finmind.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Codex"
+        ```powershell
+        curl.exe -o AGENTS.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Cursor"
+        ```powershell
+        mkdir .cursor\rules -Force
+        curl.exe -o .cursor\rules\finmind.mdc https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Windsurf"
+        ```powershell
+        curl.exe -o .windsurfrules https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+    === "Gemini"
+        ```powershell
+        curl.exe -o GEMINI.md https://raw.githubusercontent.com/FinMind/FinMind/master/.claude/commands/finmind.md
+        ```
+
+    > 若你用 **WSL** 或 **Git Bash**，則上方 macOS / Linux 的指令可直接照用，不需改寫。
+
 ### 步驟 2: 設定 Token
 
 至 [FinMind](https://finmindtrade.com/analysis/#/account/register) 註冊並驗證信箱後，取得 Token。
@@ -42,6 +69,16 @@ export FINMIND_TOKEN="your_token_here"
 ```
 
 建議加到 `~/.bashrc` 或 `~/.zshrc`，這樣每次開終端都會自動載入。
+
+??? note "🪟 Windows（PowerShell）設定 Token"
+    PowerShell 不用 `export`，請改用：
+
+    ```powershell
+    $env:FINMIND_TOKEN="your_token_here"   # 僅本次終端有效
+    setx FINMIND_TOKEN "your_token_here"   # 永久保存（需重開終端才生效）
+    ```
+
+    用 **WSL** 或 **Git Bash** 的話，`export` 與 `~/.bashrc` 寫法與 macOS / Linux 相同。
 
 ### 步驟 3: 使用
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ markdown_extensions:
         base_path: docs
     - markdown.extensions.meta:
     - admonition
+    - pymdownx.details   # 可摺疊的 admonition（??? 收合區塊）
     - attr_list          # 連結/元素屬性（例如外連開新分頁）
     - md_in_html
     - pymdownx.highlight:


### PR DESCRIPTION
## 背景
為學校演講準備：AgentSkill 頁面的安裝指令原本只寫 macOS/Linux shell（`mkdir -p` / `curl` / `export` / `~/.bashrc`），Windows 學生無法直接照做。

## 設計重點：用「收合」避免頁面變長
Windows 指令放在預設**收合**的 `???` 區塊（`pymdownx.details`），mac/Linux 讀者畫面幾乎不變，Windows 使用者點開才展開。

## 修改內容
- **mkdocs.yml**：啟用 `pymdownx.details`
- **AgentSkill.md / AgentSkill.en.md**：
  - 步驟 1（下載 Skill）：新增收合的「🪟 Windows (PowerShell)」區塊，內含 Claude Code / Codex / Cursor / Windsurf / Gemini 五個 PowerShell 分頁
    - 用 `curl.exe`（提醒 PowerShell 的 `curl` 是 `Invoke-WebRequest` 別名）+ `mkdir -Force`
  - 步驟 2（設定 Token）：新增收合的 Windows 區塊（`$env:` 與 `setx`）
  - 兩處都註明：用 **WSL / Git Bash** 可直接照用 macOS/Linux 指令

## 驗證
`mkdocs build` exit 0、無 error；收合區塊（`<details>`）與巢狀分頁皆正常渲染（中英文頁面各 2 個收合區塊）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)