### PR TITLE
docs: TaiwanStockActiveETFInfo 主動式ETF清單（free）

### DIFF
--- a/docs/WhatIsNew.en.md
+++ b/docs/WhatIsNew.en.md
@@ -1,3 +1,6 @@
+#### 2026-07-11
+* Added [Taiwan Active ETF List TaiwanStockActiveETFInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockactiveetfinfo): a list / basic-info table of Taiwan-listed active ETFs (TWSE-listed + TPEx OTC), with columns `date`, `stock_id` (ETF code), `stock_name` (ETF name), `category` (ETF category: domestic / foreign), and `type` (market type: twse / tpex); the source is the exchange's official list and updates automatically as new active ETFs are listed
+
 #### 2026-07-01
 * Added [Taiwan Option VIX TaiwanOptionVix](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptionvix-backersponsor): data range 2026-03-01 ~ now
 * Added [Convertible Bond Monthly Analysis TaiwanStockConvertibleBondMonthlyAnalysis](https://finmind.github.io/en/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebondmonthlyanalysis-backersponsor): data range 2026-05-01 ~ now

--- a/docs/WhatIsNew.md
+++ b/docs/WhatIsNew.md
@@ -1,3 +1,6 @@
+#### 2026-07-11
+* 新增 [主動式ETF清單 TaiwanStockActiveETFInfo](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstockactiveetfinfo)：台灣掛牌主動式 ETF（上市 TWSE + 上櫃 TPEX）清單／基本資料，欄位含 `date`、`stock_id`（ETF 代號）、`stock_name`（ETF 名稱）、`category`（ETF 分類：domestic 國內／foreign 跨國）、`type`（市場別：twse 上市／tpex 上櫃）；來源為交易所官方清單，隨新主動式 ETF 掛牌自動更新
+
 #### 2026-07-01
 * 新增 [臺指選擇權波動率指數 TaiwanOptionVix](https://finmind.github.io/tutor/TaiwanMarket/Derivative/#taiwanoptionvix-backersponsor)：資料區間 2026-03-01 ~ now
 * 新增 [可轉換公司債月份分析表 TaiwanStockConvertibleBondMonthlyAnalysis](https://finmind.github.io/tutor/TaiwanMarket/ConvertibleBond/#taiwanstockconvertiblebondmonthlyanalysis-backersponsor)：資料區間 2026-05-01 ~ now

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -130,12 +130,18 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 
 ---
 
-## Taiwan Market - Technical (20 datasets)
+## Taiwan Market - Technical (21 datasets)
 
 ### TaiwanStockInfo (台股總覽)
 - Tier: Free
 - Params: dataset=TaiwanStockInfo
 - Columns: industry_category (str), stock_id (str), stock_name (str), type (str), date (str)
+
+### TaiwanStockActiveETFInfo (主動式ETF清單)
+- Tier: Free
+- Params: dataset=TaiwanStockActiveETFInfo
+- Columns: date (str), stock_id (str), stock_name (str), category (str), type (str)
+- Note: List / basic info of Taiwan-listed active ETFs (TWSE-listed + TPEx OTC). category is the ETF category (domestic / foreign); type is the market type (twse / tpex). Sourced from the exchange's official list; no data_id needed — the whole list is returned and updates automatically as new active ETFs are listed.
 
 ### TaiwanStockInfoWithWarrant (台股總覽含權證)
 - Tier: Free

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -51,10 +51,10 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - [Update Token](https://finmind.github.io/update_token/): Self-service token reset on the [user info page](https://finmindtrade.com/analysis/#/account/user). Old token is invalidated immediately and all devices are signed out — no need to contact support.
 - [API Usage Count](https://finmind.github.io/api_usage_count/): Check API usage via `GET https://api.web.finmindtrade.com/v2/user_info` (Authorization: Bearer {token}). Returns `user_count` (current usage) and `api_request_limit` (quota). HTTP 402 when quota exceeded.
 
-### Taiwan Market (79 datasets)
+### Taiwan Market (80 datasets)
 
-- [Taiwan DataList](https://finmind.github.io/tutor/TaiwanMarket/DataList/): Full list of 80 Taiwan datasets
-- [Technical](https://finmind.github.io/tutor/TaiwanMarket/Technical/): TaiwanStockInfo, TaiwanStockPrice, TaiwanStockPriceAdj, TaiwanStockPriceTick, TaiwanStockPER, TaiwanStockKBar, TaiwanStockWeekPrice, TaiwanStockMonthPrice, TaiwanStockDayTrading, TaiwanStockTotalReturnIndex, TaiwanVariousIndicators5Seconds, TaiwanStockTradingDate, etc.
+- [Taiwan DataList](https://finmind.github.io/tutor/TaiwanMarket/DataList/): Full list of 81 Taiwan datasets
+- [Technical](https://finmind.github.io/tutor/TaiwanMarket/Technical/): TaiwanStockInfo, TaiwanStockActiveETFInfo, TaiwanStockPrice, TaiwanStockPriceAdj, TaiwanStockPriceTick, TaiwanStockPER, TaiwanStockKBar, TaiwanStockWeekPrice, TaiwanStockMonthPrice, TaiwanStockDayTrading, TaiwanStockTotalReturnIndex, TaiwanVariousIndicators5Seconds, TaiwanStockTradingDate, etc.
 - [Chip (Institutional)](https://finmind.github.io/tutor/TaiwanMarket/Chip/): TaiwanStockMarginPurchaseShortSale, TaiwanStockInstitutionalInvestorsBuySell, TaiwanStockInstitutionalInvestorsBuySellWide, TaiwanStockShareholding, TaiwanStockHoldingSharesPer, TaiwanStockSecuritiesLending, TaiwanStockTradingDailyReport, TaiwanStockBlockTradingDailyReport, TaiwanStockBlockTrade, TaiwanStockLoanCollateralBalance, TaiwanstockGovernmentBankBuySell, etc.
 - [Fundamental](https://finmind.github.io/tutor/TaiwanMarket/Fundamental/): TaiwanStockCashFlowsStatement, TaiwanStockFinancialStatements, TaiwanStockBalanceSheet, TaiwanStockDividend, TaiwanStockDividendResult, TaiwanStockMonthRevenue, TaiwanStockMarketValue, etc.
 - [Derivative](https://finmind.github.io/tutor/TaiwanMarket/Derivative/): TaiwanFuturesDaily, TaiwanOptionDaily, TaiwanFuturesTick, TaiwanFuturesSpreadTick, TaiwanOptionTick, TaiwanFuturesInstitutionalInvestors, TaiwanOptionInstitutionalInvestors, TaiwanFuturesDealerTradingVolumeDaily, TaiwanOptionDealerTradingVolumeDaily, TaiwanFuturesSpreadTrading, TaiwanOptionVix, etc.

--- a/docs/tutor/TaiwanMarket/DataList.en.md
+++ b/docs/tutor/TaiwanMarket/DataList.en.md
@@ -1,8 +1,9 @@
-In the Taiwan financial market, we have 83 datasets, as listed below:
+In the Taiwan financial market, we have 84 datasets, as listed below:
 
 #### Technical
 
 - [Taiwan Stock Overview TaiwanStockInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfo)
+- [Taiwan Active ETF List TaiwanStockActiveETFInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockactiveetfinfo)
 - [Taiwan Stock Overview (with Warrants) TaiwanStockInfoWithWarrant](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrant)
 - [Taiwan Warrant Underlying Reference Table TaiwanStockInfoWithWarrantSummary](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrantsummary-sponsor)
 - [Taiwan Stock Trading Dates TaiwanStockTradingDate](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstocktradingdate)

--- a/docs/tutor/TaiwanMarket/DataList.md
+++ b/docs/tutor/TaiwanMarket/DataList.md
@@ -1,8 +1,9 @@
-在台灣金融市場，我們擁有 83 種資料集，如下:
+在台灣金融市場，我們擁有 84 種資料集，如下:
 
 #### 技術面 Technical
 
 - [台股總覽 TaiwanStockInfo](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstockinfo)
+- [主動式ETF清單 TaiwanStockActiveETFInfo](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstockactiveetfinfo)
 - [台股總覽(含權證) TaiwanStockInfoWithWarrant](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrant)
 - [台股權證標的對照表 TaiwanStockInfoWithWarrantSummary](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrantsummary-sponsor)
 - [台股交易日 TaiwanStockTradingDate](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstocktradingdate)

--- a/docs/tutor/TaiwanMarket/Technical.en.md
+++ b/docs/tutor/TaiwanMarket/Technical.en.md
@@ -1,6 +1,7 @@
-In Taiwan stock technical data, we have 20 datasets, as follows:
+In Taiwan stock technical data, we have 21 datasets, as follows:
 
 - [Taiwan Stock Overview TaiwanStockInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfo)
+- [Taiwan Active ETF List TaiwanStockActiveETFInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockactiveetfinfo)
 - [Taiwan Stock Overview (with Warrants) TaiwanStockInfoWithWarrant](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrant)
 - [Taiwan Warrant Underlying Reference Table TaiwanStockInfoWithWarrantSummary](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrantsummary-sponsor)
 - [Taiwan Stock Trading Date TaiwanStockTradingDate](https://finmind.github.io/en/tutor/TaiwanMarket/Technical/#taiwanstocktradingdate)
@@ -91,6 +92,79 @@ In Taiwan stock technical data, we have 20 datasets, as follows:
             stock_name: str, # stock name
             type: str, # market type
             date: str # update date
+        }
+        ```
+
+
+----------------------------------
+#### Taiwan Active ETF List TaiwanStockActiveETFInfo
+
+- This table lists Taiwan-listed active ETFs (TWSE-listed + TPEx OTC), including the ETF code, name, ETF category, and market type!
+- The data source is the exchange's official list, and it updates automatically as new active ETFs are listed
+- `category` is the ETF category: `domestic` (invests domestically) / `foreign` (invests cross-border)
+- `type` is the market type: `twse` (listed) / `tpex` (OTC)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_active_etf_info()
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockActiveETFInfo",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset = "TaiwanStockActiveETFInfo"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | stock_name         | category   | type   |
+        |---:|:-----------|-----------:|:-------------------|:-----------|:-------|
+        |  0 | 2026-07-11 |     00980A | 主動野村臺灣優選   | domestic   | twse   |
+        |  1 | 2026-07-11 |     00981A | 主動統一台股增長   | domestic   | twse   |
+        |  2 | 2026-07-11 |     00982A | 主動群益台灣強棒   | domestic   | twse   |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # ETF code
+            stock_name: str, # ETF name
+            category: str, # ETF category (domestic / foreign)
+            type: str # market type (twse / tpex)
         }
         ```
 

--- a/docs/tutor/TaiwanMarket/Technical.md
+++ b/docs/tutor/TaiwanMarket/Technical.md
@@ -1,6 +1,7 @@
-在台股技術面，我們擁有 20 種資料集，如下:
+在台股技術面，我們擁有 21 種資料集，如下:
 
 - [台股總覽 TaiwanStockInfo](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstockinfo)
+- [主動式ETF清單 TaiwanStockActiveETFInfo](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstockactiveetfinfo)
 - [台股總覽(含權證) TaiwanStockInfoWithWarrant](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrant)
 - [台股權證標的對照表 TaiwanStockInfoWithWarrantSummary](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstockinfowithwarrantsummary-sponsor)
 - [台股交易日 TaiwanStockTradingDate](https://finmind.github.io/tutor/TaiwanMarket/Technical/#taiwanstocktradingdate)
@@ -91,6 +92,79 @@
             stock_name: str, # 股票名稱
             type: str, # 市場別
             date: str # 更新日期
+        }
+        ```
+
+
+----------------------------------
+#### 主動式ETF清單 TaiwanStockActiveETFInfo
+
+- 這張資料表列出台灣掛牌的主動式 ETF（上市 TWSE + 上櫃 TPEX）清單與基本資料，包含 ETF 代號、名稱、ETF 分類與市場別！
+- 資料來源為交易所官方清單，隨新主動式 ETF 掛牌自動更新
+- `category` 為 ETF 分類：`domestic`（國內投資）／`foreign`（跨國投資）
+- `type` 為市場別：`twse`（上市）／`tpex`（上櫃）
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_active_etf_info()
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # 參考登入，獲取金鑰
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockActiveETFInfo",
+        }
+        resp = requests.get(url, headers=headers, params=parameter)
+        data = resp.json()
+        data = pd.DataFrame(data["data"])
+        print(data.head())
+
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # 參考登入，獲取金鑰
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset = "TaiwanStockActiveETFInfo"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id | stock_name         | category   | type   |
+        |---:|:-----------|-----------:|:-------------------|:-----------|:-------|
+        |  0 | 2026-07-11 |     00980A | 主動野村臺灣優選   | domestic   | twse   |
+        |  1 | 2026-07-11 |     00981A | 主動統一台股增長   | domestic   | twse   |
+        |  2 | 2026-07-11 |     00982A | 主動群益台灣強棒   | domestic   | twse   |
+    === "Schema"
+        ```
+        {
+            date: str, # 日期
+            stock_id: str, # ETF 代號
+            stock_name: str, # ETF 名稱
+            category: str, # ETF 分類（domestic 國內／foreign 跨國）
+            type: str # 市場別（twse 上市／tpex 上櫃）
         }
         ```
 


### PR DESCRIPTION
新增免費 info 資料集 **TaiwanStockActiveETFInfo**（主動式ETF清單 / Taiwan Active ETF List），比照免費的 `TaiwanStockInfo`「台股總覽」寫法（同樣 heading／anchor 慣例，無 `-sponsor` 後綴）。

## 內容
台灣掛牌主動式 ETF（上市 TWSE + 上櫃 TPEX）清單／基本資料，來源為交易所官方清單，隨新主動式 ETF 掛牌自動更新。無需 `data_id`，回傳整份清單。

### 欄位 Columns
| 欄位 | 說明 |
|---|---|
| `date` | 日期 |
| `stock_id` | ETF 代號 |
| `stock_name` | ETF 名稱 |
| `category` | ETF 分類：`domestic`（國內）／`foreign`（跨國） |
| `type` | 市場別：`twse`（上市）／`tpex`（上櫃） |

## 修改檔案
- `docs/tutor/TaiwanMarket/Technical.md` / `.en.md`：技術面 20 → 21；清單連結 + 完整雙語段落（欄位表 + Package `api.taiwan_stock_active_etf_info()` / Python-request / R 範例 + DataFrame/Schema output）
- `docs/tutor/TaiwanMarket/DataList.md` / `.en.md`：資料集總數 **83 → 84** + 清單連結
- `docs/WhatIsNew.md` / `.en.md`：新增 2026-07-11 條目
- `docs/llms.txt` / `docs/llms-full.txt`：比照 TaiwanStockInfo 補列（Tier: Free）

Free tier，未標 sponsor。文件僅描述對外欄位行為，來源以「交易所官方清單」抽象描述，未揭露內部 API 細節。

**DO NOT MERGE** — 待 review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)