### PR TITLE
docs(mcp): add Windows installation tips to MCP page

### DIFF
--- a/docs/tutor/ai/Mcp.en.md
+++ b/docs/tutor/ai/Mcp.en.md
@@ -35,6 +35,15 @@ After install, run `/reload-plugins` to connect and `/mcp` to verify. (The plugi
 
 **Codex CLI** uses a different config format (`[mcp_servers]` in `~/.codex/config.toml`), or a one-liner: `codex mcp add finmind --env FINMIND_TOKEN=... -- uvx finmind-mcp`.
 
+!!! tip "Windows users"
+    The commands above use macOS / Linux syntax. On Windows, use **PowerShell** instead:
+
+    - Install uv: `winget install --id astral-sh.uv -e` (close and reopen PowerShell afterwards so PATH takes effect), then verify with `uvx finmind-mcp --help`.
+    - Set the token: `$env:FINMIND_TOKEN = "your_token_here"` (current window only) or `setx FINMIND_TOKEN "your_token_here"` (persistent; restart apps to pick it up) — or simply put it in the config file's `env` block above, which is the most reliable option.
+    - If your tool (e.g. Claude Desktop) reports the command not found or fails to connect: GUI apps see a different PATH than your terminal. Run `where.exe uvx` to find the full path (usually `C:\Users\<name>\.local\bin\uvx.exe`) and use it as `command` in the config; escape backslashes as `\\` in JSON.
+
+    For the full walkthrough (pipx route, per-host Windows config paths, troubleshooting), see the [Windows installation guide](https://github.com/FinMind/FinMind-MCP/blob/master/install/windows.md).
+
 For per-host config file locations, the `claude mcp add` / `gemini mcp add` / `codex mcp add` one-liners, and verification steps, see the [FinMind-MCP install guides](https://github.com/FinMind/FinMind-MCP/tree/master/install).
 
 ## Examples { #examples }

--- a/docs/tutor/ai/Mcp.md
+++ b/docs/tutor/ai/Mcp.md
@@ -35,6 +35,15 @@
 
 **Codex CLI** 的設定格式不同（用 `~/.codex/config.toml` 的 `[mcp_servers]`），或一行 `codex mcp add finmind --env FINMIND_TOKEN=... -- uvx finmind-mcp`。
 
+!!! tip "Windows 使用者"
+    上述指令以 macOS / Linux 為例，Windows 請改在 **PowerShell** 操作：
+
+    - 安裝 uv：`winget install --id astral-sh.uv -e`（裝完關閉 PowerShell 重開新視窗讓 PATH 生效），驗證 `uvx finmind-mcp --help`。
+    - 設定 Token：`$env:FINMIND_TOKEN = "your_token_here"`（僅當前視窗）或 `setx FINMIND_TOKEN "your_token_here"`（永久，需重開程式生效）；也可直接填入上方設定檔的 `env` 區塊，最不易出錯。
+    - 若工具（如 Claude Desktop）顯示找不到指令或連線失敗：圖形介面應用讀到的 PATH 和終端機不同，請用 `where.exe uvx` 查出完整路徑（通常是 `C:\Users\<帳號>\.local\bin\uvx.exe`），填入設定檔的 `command`；JSON 中反斜線要寫成 `\\`。
+
+    完整步驟（pipx 路線、各 host 的 Windows 設定檔路徑、常見問題）詳見 [Windows 安裝指引](https://github.com/FinMind/FinMind-MCP/blob/master/install/windows.md)。
+
 各 host 的設定檔位置、`claude mcp add` / `gemini mcp add` / `codex mcp add` 指令與驗證方式，詳見 [FinMind-MCP 安裝指南](https://github.com/FinMind/FinMind-MCP/tree/master/install)。
 
 ## 範例 { #examples }


### PR DESCRIPTION
## 背景

用戶反映不知道如何在 Windows 安裝 FinMind MCP。`docs/tutor/ai/Mcp.md` 的安裝段只有 macOS / Linux 語法（`export`），Windows 使用者缺前置步驟。

## 內容

`Mcp.md` + `Mcp.en.md`（中英同步）在安裝段的 Codex 說明後新增「Windows 使用者」admonition：

- PowerShell 用 `winget` 裝 uv（含重開視窗讓 PATH 生效的提醒）
- Token 的 `$env:` / `setx` 語法，並建議直接填設定檔 `env` 區塊
- 最常見的坑：GUI 應用（Claude Desktop）讀到的 PATH 和終端機不同 → `where.exe` 查完整路徑填 `command`、JSON 反斜線寫 `\\`
- 連到 FinMind-MCP 的完整 [Windows 安裝指引](https://github.com/FinMind/FinMind-MCP/blob/master/install/windows.md)

## 相依

連結目標 `install/windows.md` 由 FinMind/FinMind-MCP#14 新增，**建議先 merge 那邊**再 merge 本 PR，連結才不會 404。

只描述對外安裝行為，無任何內部細節。

🤖 Generated with [Claude Code](https://claude.com/claude-code)