### PR TITLE
docs: 修正主動式 ETF 三個資料集的 anchor 連結

### DIFF
--- a/docs/WhatIsNew.en.md
+++ b/docs/WhatIsNew.en.md
@@ -1,7 +1,7 @@
 #### 2026-07-13
-* Added [Active ETF Daily Holding TaiwanStockActiveETFHolding](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholding-sponsor): data range 2025-05-05 ~ now
-* Added [Active ETF Daily Holding Change TaiwanStockActiveETFHoldingChange](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholdingchange-sponsor): data range 2025-05-05 ~ now
-* Added [Taiwan Active ETF List TaiwanStockActiveETFInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfinfo): a list / basic-info table of Taiwan-listed active ETFs (TWSE-listed + TPEx OTC), with columns `date`, `stock_id` (ETF code), `stock_name` (ETF name), `category` (ETF category: domestic / foreign), and `type` (market type: twse / tpex)
+* Added [Active ETF Daily Holding TaiwanStockActiveETFHolding](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#active-etf-daily-holding-taiwanstockactiveetfholding-only-available-for-sponsor-members): data range 2025-05-05 ~ now
+* Added [Active ETF Daily Holding Change TaiwanStockActiveETFHoldingChange](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#active-etf-daily-holding-change-taiwanstockactiveetfholdingchange-only-available-for-sponsor-members): data range 2025-05-05 ~ now
+* Added [Taiwan Active ETF List TaiwanStockActiveETFInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwan-active-etf-list-taiwanstockactiveetfinfo): a list / basic-info table of Taiwan-listed active ETFs (TWSE-listed + TPEx OTC), with columns `date`, `stock_id` (ETF code), `stock_name` (ETF name), `category` (ETF category: domestic / foreign), and `type` (market type: twse / tpex)
 
 #### 2026-07-12
 * Added [Disclaimer & Data Licensing](https://finmind.github.io/en/Disclaimer/): explains FinMind's data sources and licensing basis (data obtained via government open data platforms is used under the Open Government Data License of Taiwan), the scope of the license granted to users (the right to use this service, excluding redistribution / resale / mirroring), and disclaimers such as all data being for reference only

--- a/docs/WhatIsNew.md
+++ b/docs/WhatIsNew.md
@@ -1,7 +1,7 @@
 #### 2026-07-13
-* 新增 [主動式ETF每日持股明細 TaiwanStockActiveETFHolding](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholding-sponsor)：資料區間 2025-05-05 ~ now
-* 新增 [主動式ETF每日持股異動（買賣）TaiwanStockActiveETFHoldingChange](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholdingchange-sponsor)：資料區間 2025-05-05 ~ now
-* 新增 [主動式ETF清單 TaiwanStockActiveETFInfo](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfinfo)：台灣掛牌主動式 ETF（上市 TWSE + 上櫃 TPEX）清單／基本資料，欄位含 `date`、`stock_id`（ETF 代號）、`stock_name`（ETF 名稱）、`category`（ETF 分類：domestic 國內／foreign 跨國）、`type`（市場別：twse 上市／tpex 上櫃）
+* 新增 [主動式ETF每日持股明細 TaiwanStockActiveETFHolding](https://finmind.github.io/tutor/TaiwanMarket/Chip/#etf-taiwanstockactiveetfholding-sponsor)：資料區間 2025-05-05 ~ now
+* 新增 [主動式ETF每日持股異動（買賣）TaiwanStockActiveETFHoldingChange](https://finmind.github.io/tutor/TaiwanMarket/Chip/#etftaiwanstockactiveetfholdingchange-sponsor)：資料區間 2025-05-05 ~ now
+* 新增 [主動式ETF清單 TaiwanStockActiveETFInfo](https://finmind.github.io/tutor/TaiwanMarket/Chip/#etf-taiwanstockactiveetfinfo)：台灣掛牌主動式 ETF（上市 TWSE + 上櫃 TPEX）清單／基本資料，欄位含 `date`、`stock_id`（ETF 代號）、`stock_name`（ETF 名稱）、`category`（ETF 分類：domestic 國內／foreign 跨國）、`type`（市場別：twse 上市／tpex 上櫃）
 
 #### 2026-07-12
 * 新增 [免責聲明與資料授權說明](https://finmind.github.io/Disclaimer/) 頁面：說明 FinMind 之資料來源與授權依據（經政府資料開放平臺取得之資料，依《政府資料開放授權條款》使用）、使用者取得之授權範圍（本服務之使用權，不含對外再散布／轉售／鏡像），以及資料僅供參考等免責事項

--- a/docs/tutor/TaiwanMarket/Chip.en.md
+++ b/docs/tutor/TaiwanMarket/Chip.en.md
@@ -22,9 +22,9 @@ In Taiwan stock chip data, we have 24 datasets as follows:
 - [Block Trading Daily Report TaiwanStockBlockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockblocktradingdailyreport-sponsor)
 - [Block Trade Daily Transactions TaiwanStockBlockTrade](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockblocktrade-sponsor)
 - [Loan Collateral Balance TaiwanStockLoanCollateralBalance](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockloancollateralbalance-sponsor)
-- [Taiwan Active ETF List TaiwanStockActiveETFInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfinfo)
-- [Active ETF Daily Holding TaiwanStockActiveETFHolding](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholding-sponsor)
-- [Active ETF Daily Holding Change TaiwanStockActiveETFHoldingChange](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholdingchange-sponsor)
+- [Taiwan Active ETF List TaiwanStockActiveETFInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwan-active-etf-list-taiwanstockactiveetfinfo)
+- [Active ETF Daily Holding TaiwanStockActiveETFHolding](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#active-etf-daily-holding-taiwanstockactiveetfholding-only-available-for-sponsor-members)
+- [Active ETF Daily Holding Change TaiwanStockActiveETFHoldingChange](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#active-etf-daily-holding-change-taiwanstockactiveetfholdingchange-only-available-for-sponsor-members)
 - [Disposition Securities Period TaiwanStockDispositionSecuritiesPeriod](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdispositionsecuritiesperiod-backersponsor)
 - [Day Trading Borrowing Fee Rate TaiwanStockDayTradingBorrowingFeeRate](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdaytradingborrowingfeerate-backersponsor)
 

--- a/docs/tutor/TaiwanMarket/Chip.md
+++ b/docs/tutor/TaiwanMarket/Chip.md
@@ -22,9 +22,9 @@
 - [鉅額交易買賣日報表 TaiwanStockBlockTradingDailyReport](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockblocktradingdailyreport-sponsor)
 - [鉅額交易日成交資訊 TaiwanStockBlockTrade](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockblocktrade-sponsor)
 - [借貸款項擔保品餘額表 TaiwanStockLoanCollateralBalance](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockloancollateralbalance-sponsor)
-- [主動式ETF清單 TaiwanStockActiveETFInfo](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfinfo)
-- [主動式ETF每日持股明細 TaiwanStockActiveETFHolding](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholding-sponsor)
-- [主動式ETF每日持股異動（買賣）TaiwanStockActiveETFHoldingChange](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholdingchange-sponsor)
+- [主動式ETF清單 TaiwanStockActiveETFInfo](https://finmind.github.io/tutor/TaiwanMarket/Chip/#etf-taiwanstockactiveetfinfo)
+- [主動式ETF每日持股明細 TaiwanStockActiveETFHolding](https://finmind.github.io/tutor/TaiwanMarket/Chip/#etf-taiwanstockactiveetfholding-sponsor)
+- [主動式ETF每日持股異動（買賣）TaiwanStockActiveETFHoldingChange](https://finmind.github.io/tutor/TaiwanMarket/Chip/#etftaiwanstockactiveetfholdingchange-sponsor)
 - [公布處置有價證券表 TaiwanStockDispositionSecuritiesPeriod](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockdispositionsecuritiesperiod-backersponsor)
 - [現股當日沖銷券差借券費率 TaiwanStockDayTradingBorrowingFeeRate](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockdaytradingborrowingfeerate-backersponsor)
 

--- a/docs/tutor/TaiwanMarket/DataList.en.md
+++ b/docs/tutor/TaiwanMarket/DataList.en.md
@@ -46,9 +46,9 @@ In the Taiwan financial market, we have 86 datasets, as listed below:
 - [Block Trade Daily Report TaiwanStockBlockTradingDailyReport](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockblocktradingdailyreport-sponsor)
 - [Block Trade Daily Trading Information TaiwanStockBlockTrade](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockblocktrade-sponsor)
 - [Loan Collateral Balance Table TaiwanStockLoanCollateralBalance](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockloancollateralbalance-sponsor)
-- [Taiwan Active ETF List TaiwanStockActiveETFInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfinfo)
-- [Active ETF Daily Holding TaiwanStockActiveETFHolding](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholding-sponsor)
-- [Active ETF Daily Holding Change TaiwanStockActiveETFHoldingChange](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholdingchange-sponsor)
+- [Taiwan Active ETF List TaiwanStockActiveETFInfo](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwan-active-etf-list-taiwanstockactiveetfinfo)
+- [Active ETF Daily Holding TaiwanStockActiveETFHolding](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#active-etf-daily-holding-taiwanstockactiveetfholding-only-available-for-sponsor-members)
+- [Active ETF Daily Holding Change TaiwanStockActiveETFHoldingChange](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#active-etf-daily-holding-change-taiwanstockactiveetfholdingchange-only-available-for-sponsor-members)
 - [Disposition Securities Announcement Table TaiwanStockDispositionSecuritiesPeriod](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdispositionsecuritiesperiod-backersponsor)
 - [Cash Day-Trading Short-Borrow Fee Rate TaiwanStockDayTradingBorrowingFeeRate](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdaytradingborrowingfeerate-backersponsor)
 

--- a/docs/tutor/TaiwanMarket/DataList.md
+++ b/docs/tutor/TaiwanMarket/DataList.md
@@ -46,9 +46,9 @@
 - [鉅額交易買賣日報表 TaiwanStockBlockTradingDailyReport](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockblocktradingdailyreport-sponsor)
 - [鉅額交易日成交資訊 TaiwanStockBlockTrade](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockblocktrade-sponsor)
 - [借貸款項擔保品餘額表 TaiwanStockLoanCollateralBalance](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockloancollateralbalance-sponsor)
-- [主動式ETF清單 TaiwanStockActiveETFInfo](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfinfo)
-- [主動式ETF每日持股明細 TaiwanStockActiveETFHolding](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholding-sponsor)
-- [主動式ETF每日持股異動（買賣）TaiwanStockActiveETFHoldingChange](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockactiveetfholdingchange-sponsor)
+- [主動式ETF清單 TaiwanStockActiveETFInfo](https://finmind.github.io/tutor/TaiwanMarket/Chip/#etf-taiwanstockactiveetfinfo)
+- [主動式ETF每日持股明細 TaiwanStockActiveETFHolding](https://finmind.github.io/tutor/TaiwanMarket/Chip/#etf-taiwanstockactiveetfholding-sponsor)
+- [主動式ETF每日持股異動（買賣）TaiwanStockActiveETFHoldingChange](https://finmind.github.io/tutor/TaiwanMarket/Chip/#etftaiwanstockactiveetfholdingchange-sponsor)
 - [公布處置有價證券表 TaiwanStockDispositionSecuritiesPeriod](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockdispositionsecuritiesperiod-backersponsor)
 - [現股當日沖銷券差借券費率 TaiwanStockDayTradingBorrowingFeeRate](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockdaytradingborrowingfeerate-backersponsor)
 


### PR DESCRIPTION
## 問題

主動式 ETF 三個資料集的連結 anchor 錯誤，點擊後停在 Chip 頁面頂端而非對應段落：

- 主動式ETF清單 `TaiwanStockActiveETFInfo`
- 主動式ETF每日持股明細 `TaiwanStockActiveETFHolding`
- 主動式ETF每日持股異動（買賣）`TaiwanStockActiveETFHoldingChange`

## 根因

mkdocs toc slugify 產生 heading id 時會移除中文、但保留中文標題中的 ASCII「ETF」，所以實際 anchor 帶有 `etf-` 前綴（HoldingChange 因「（買賣）」全形括號後無空格，連字號也沒有）。原連結少了這段，指向不存在的 anchor。

## 修正（皆已比對 finmind.github.io 線上頁面實際 id）

| 資料集 | 中文頁 anchor | 英文頁 anchor |
|---|---|---|
| Info | `#etf-taiwanstockactiveetfinfo` | `#taiwan-active-etf-list-taiwanstockactiveetfinfo` |
| Holding | `#etf-taiwanstockactiveetfholding-sponsor` | `#active-etf-daily-holding-taiwanstockactiveetfholding-only-available-for-sponsor-members` |
| HoldingChange | `#etftaiwanstockactiveetfholdingchange-sponsor` | `#active-etf-daily-holding-change-taiwanstockactiveetfholdingchange-only-available-for-sponsor-members` |

修改檔案（中英文各 3 個連結）：`Chip.md` / `Chip.en.md` 頁首目錄、`DataList.md` / `DataList.en.md`、`WhatIsNew.md` / `WhatIsNew.en.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)