### PR TITLE
docs: 校正台股各處資料集數量，統一計數規則

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -286,7 +286,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 
 ---
 
-## Taiwan Market - Chip / Institutional (23 datasets)
+## Taiwan Market - Chip / Institutional (24 datasets)
 
 ### TaiwanStockMarginPurchaseShortSale (個股融資融劵表)
 - Tier: Free (with data_id) / Backer/Sponsor (all stocks by start_date only)
@@ -566,7 +566,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 
 ---
 
-## Taiwan Market - Derivative (18 datasets)
+## Taiwan Market - Derivative (20 datasets)
 
 ### TaiwanFutOptDailyInfo (期貨、選擇權日成交資訊總覽)
 - Tier: Free
@@ -740,7 +740,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 
 ---
 
-## Taiwan Market - Convertible Bond (5 datasets)
+## Taiwan Market - Convertible Bond (6 datasets)
 
 ### TaiwanStockConvertibleBondInfo (可轉債總覽)
 - Tier: Backer/Sponsor

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -51,9 +51,9 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - [Update Token](https://finmind.github.io/update_token/): Self-service token reset on the [user info page](https://finmindtrade.com/analysis/#/account/user). Old token is invalidated immediately and all devices are signed out — no need to contact support.
 - [API Usage Count](https://finmind.github.io/api_usage_count/): Check API usage via `GET https://api.web.finmindtrade.com/v2/user_info` (Authorization: Bearer {token}). Returns `user_count` (current usage) and `api_request_limit` (quota). HTTP 402 when quota exceeded.
 
-### Taiwan Market (82 datasets)
+### Taiwan Market (90 datasets)
 
-- [Taiwan DataList](https://finmind.github.io/tutor/TaiwanMarket/DataList/): Full list of 83 Taiwan datasets
+- [Taiwan DataList](https://finmind.github.io/tutor/TaiwanMarket/DataList/): Full list of 90 Taiwan datasets
 - [Technical](https://finmind.github.io/tutor/TaiwanMarket/Technical/): TaiwanStockInfo, TaiwanStockPrice, TaiwanStockPriceAdj, TaiwanStockPriceTick, TaiwanStockPER, TaiwanStockKBar, TaiwanStockWeekPrice, TaiwanStockMonthPrice, TaiwanStockDayTrading, TaiwanStockTotalReturnIndex, TaiwanVariousIndicators5Seconds, TaiwanStockTradingDate, etc.
 - [Chip (Institutional)](https://finmind.github.io/tutor/TaiwanMarket/Chip/): TaiwanStockMarginPurchaseShortSale, TaiwanStockInstitutionalInvestorsBuySell, TaiwanStockInstitutionalInvestorsBuySellWide, TaiwanStockShareholding, TaiwanStockHoldingSharesPer, TaiwanStockSecuritiesLending, TaiwanStockTradingDailyReport, TaiwanStockBlockTradingDailyReport, TaiwanStockBlockTrade, TaiwanStockLoanCollateralBalance, TaiwanStockActiveETFInfo, TaiwanStockActiveETFHolding, TaiwanStockActiveETFHoldingChange, TaiwanStockIndustryChainMoneyFlow, TaiwanstockGovernmentBankBuySell, etc.
 - [Fundamental](https://finmind.github.io/tutor/TaiwanMarket/Fundamental/): TaiwanStockCashFlowsStatement, TaiwanStockFinancialStatements, TaiwanStockBalanceSheet, TaiwanStockDividend, TaiwanStockDividendResult, TaiwanStockMonthRevenue, TaiwanStockMarketValue, etc.

--- a/docs/tutor/TaiwanMarket/DataList.en.md
+++ b/docs/tutor/TaiwanMarket/DataList.en.md
@@ -50,6 +50,8 @@ In the Taiwan financial market, we have 90 datasets, as listed below:
 - [Active ETF Daily Holding TaiwanStockActiveETFHolding](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#active-etf-daily-holding-taiwanstockactiveetfholding-only-available-for-sponsor-members)
 - [Active ETF Daily Holding Change TaiwanStockActiveETFHoldingChange](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#active-etf-daily-holding-change-taiwanstockactiveetfholdingchange-only-available-for-sponsor-members)
 - [Industry Chain Money Flow TaiwanStockIndustryChainMoneyFlow](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#industry-chain-money-flow-taiwanstockindustrychainmoneyflow-only-available-for-sponsor-members)
+- [Disposition Securities Period TaiwanStockDispositionSecuritiesPeriod](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdispositionsecuritiesperiod-backersponsor)
+- [Day Trading Borrowing Fee Rate TaiwanStockDayTradingBorrowingFeeRate](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#taiwanstockdaytradingborrowingfeerate-backersponsor)
 
 #### Fundamental
 

--- a/docs/tutor/TaiwanMarket/Derivative.en.md
+++ b/docs/tutor/TaiwanMarket/Derivative.en.md
@@ -15,6 +15,7 @@ In Taiwan stock derivatives data, we have 20 datasets, as follows:
 - [Options Daily Trading Volume by Dealer TaiwanOptionDealerTradingVolumeDaily](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptiondealertradingvolumedaily)
 - [Futures Open Interest of Large Traders TaiwanFuturesOpenInterestLargeTraders](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesopeninterestlargetraders-backersponsor)
 - [Options Open Interest of Large Traders TaiwanOptionOpenInterestLargeTraders](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptionopeninterestlargetraders-backersponsor)
+- [Futures Spread Trading Quotes TaiwanFuturesSpreadTrading](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#futures-spread-trading-quote-table-taiwanfuturesspreadtrading-available-only-to-backer-sponsor-members)
 - [Futures Final Settlement Price TaiwanFuturesFinalSettlementPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanfuturesfinalsettlementprice-backersponsor)
 - [Options Final Settlement Price TaiwanOptionFinalSettlementPrice](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptionfinalsettlementprice-backersponsor)
 - [TAIEX Options Volatility Index TaiwanOptionVix](https://finmind.github.io/en/tutor/TaiwanMarket/Derivative/#taiwanoptionvix-backersponsor)

--- a/docs/tutor/TaiwanMarket/Derivative.md
+++ b/docs/tutor/TaiwanMarket/Derivative.md
@@ -15,6 +15,7 @@
 - [選擇權各卷商每日交易 TaiwanOptionDealerTradingVolumeDaily](https://finmind.github.io/tutor/TaiwanMarket/Derivative/#taiwanoptiondealertradingvolumedaily)
 - [期貨大額交易人未沖銷部位 TaiwanFuturesOpenInterestLargeTraders](https://finmind.github.io/tutor/TaiwanMarket/Derivative/#taiwanfuturesopeninterestlargetraders-backersponsor)
 - [選擇權大額交易人未沖銷部位 TaiwanOptionOpenInterestLargeTraders](https://finmind.github.io/tutor/TaiwanMarket/Derivative/#taiwanoptionopeninterestlargetraders-backersponsor)
+- [期貨價差行情表 TaiwanFuturesSpreadTrading](https://finmind.github.io/tutor/TaiwanMarket/Derivative/#taiwanfuturesspreadtrading-backersponsor)
 - [期貨最後結算價 TaiwanFuturesFinalSettlementPrice](https://finmind.github.io/tutor/TaiwanMarket/Derivative/#taiwanfuturesfinalsettlementprice-backersponsor)
 - [選擇權最後結算價 TaiwanOptionFinalSettlementPrice](https://finmind.github.io/tutor/TaiwanMarket/Derivative/#taiwanoptionfinalsettlementprice-backersponsor)
 - [臺指選擇權波動率指數 TaiwanOptionVix](https://finmind.github.io/tutor/TaiwanMarket/Derivative/#taiwanoptionvix-backersponsor)


### PR DESCRIPTION
## 背景

各文件的「N 種資料集 / N datasets」長期靠新增 dataset 時手動 +1 維護，已與實際內容脫鉤。本次盤點帶計數的位置，先定計數規則，再套用。

> **範圍調整**：原本一併校正 Europe / Japan / UK / US 四個市場的 `DataList` / `Technical` 頁面，依指示已移出本 PR，那 16 個檔案維持原值不動。本 PR 只保留台股（TaiwanMarket + `llms.txt` / `llms-full.txt` 的 Taiwan Market 區塊）的改動。

## 計數規則（先定義，再套用）

> **N = 該頁面（或該區塊）列出的「不重複 dataset 名稱」數量。**

| 規則 | 說明 |
|---|---|
| 依據 | 先前的校正 commit `f2bf695` 明確寫「intro 清單**唯一** dataset 名稱數」，沿用同一標準 |
| 重複查詢模式只算 1 個 | `TaiwanStockTradingDailyReport`、`TaiwanStockWarrantTradingDailyReport` 各有「query by 股票代碼 / query by 券商代碼」兩條連結，但是同一個 dataset |
| 用法小標不計數 | `#### 一次拿特定日期，所有資料` 這類是同一 dataset 的用法章節，不是 dataset |
| 清單 vs 章節不一致時 | 以「有專屬章節的 dataset」為準，**補回清單漏掉的連結**，而不是把數字改小 |
| llms-full.txt | `## ... (N datasets)` 以該區塊自己的 `###` 條目數為準（該檔是獨立維護的精簡版） |

## 修改總表

### 一、數字錯誤 → 改數字

| 檔案 | 位置 | 宣稱 | 實際 | 改成 |
|---|---|---|---|---|
| `docs/llms-full.txt` | `## Taiwan Market - Chip / Institutional` | 23 | 24 | **24** |
| `docs/llms-full.txt` | `## Taiwan Market - Derivative` | 18 | 20 | **20** |
| `docs/llms-full.txt` | `## Taiwan Market - Convertible Bond` | 5 | 6 | **6** |
| `docs/llms.txt` | `### Taiwan Market (N datasets)` | 82 | 90 | **90** |
| `docs/llms.txt` | `Full list of N Taiwan datasets` | 83 | 90 | **90** |

### 二、數字正確、清單漏列 → 補連結（數字不動）

| 檔案 | 宣稱 | 清單原有 | 補上 | 補後 |
|---|---|---|---|---|
| `docs/tutor/TaiwanMarket/Derivative.md` / `.en.md` | 20 | 19 | `TaiwanFuturesSpreadTrading` | **20** |
| `docs/tutor/TaiwanMarket/DataList.en.md` | 90 | 88 | `TaiwanStockDispositionSecuritiesPeriod`、`TaiwanStockDayTradingBorrowingFeeRate` | **90** |

兩處補上的 dataset 在對應頁面都已有專屬章節，中文版也都有列，屬於清單漏列。補完後中英文 DataList 的每個分類條數完全一致。

### 三、複驗後確認**原本就正確**、不需修改

| 檔案 | 宣稱 | 實際（不重複 dataset 名稱） | 結論 |
|---|---|---|---|
| `docs/tutor/TaiwanMarket/Chip.md` / `.en.md` | 25 | 27 條連結 − 2 組重複查詢模式 = **25** | ✅ 正確 |
| `docs/tutor/TaiwanMarket/DataList.md`（中文） | 90 | 92 條連結 − 2 組重複查詢模式 = **90** | ✅ 正確 |
| `Technical.md` / `.en.md` | 20 | 20 | ✅ |
| `Fundamental.md` / `.en.md` | 12 | 12 | ✅ |
| `RealTime.md` / `.en.md` | 4 | 4 | ✅ |
| `ConvertibleBond.md` / `.en.md` | 6 | 6 | ✅ |
| `Others.md` / `.en.md` | 3 | 3 | ✅ |
| `Materials.md` / `.en.md` | 2 | 2 | ✅ |
| `llms-full.txt` Technical / Fundamental / Real-Time / Others | 20 / 12 / 4 / 3 | 同左 | ✅ |

> 註：Chip 的 25 與 DataList 的 90 一開始看起來像「少算 2」，複驗後確認是**分點資料表的兩種查詢模式各佔一條連結**所致，依「不重複 dataset 名稱」規則原值正確。

## 已知、本 PR **未動**的項目

1. **非台股市場的計數口徑**（Europe / Japan / UK / US 的 `DataList` / `Technical`，共 16 檔）：這些頁面把 Info 類清單資料表另起一段，開頭句的數字原本只算第一段。要不要統一成「計入該市場全部 dataset」（Europe/Japan/UK = 2、US = 3）留待日後決定。
2. **「75+ 種資料集」**（7 處）：`docs/index.md`、`docs/index.en.md`、`docs/tutor/ai/AgentSkill.md`、`AgentSkill.en.md`、`docs/llms.txt`、`docs/llms-full.txt`、`docs/openapi.yaml`。是下限式說法，嚴格說沒錯但已明顯保守（目前台股 90 + 美 3 + 英 2 + 歐 2 + 日 2 + 全球經濟數據 6 = 105）。改成「100+」屬行銷用語決策。
3. **「超過 50 種 / more than 50 datasets」**（`docs/index.md`、`docs/index.en.md` 各 2 處）：同上。
4. **`llms-full.txt` 內容缺口**：Chip 區塊只有 24 個 `###`，比 tutor `Chip.md` 的 25 個 dataset 少了 `TaiwanStockDayTradingBorrowingFeeRate`。本 PR 只讓 header 數字與該檔自身內容一致（改成 24）；補上完整說明區塊建議另開 PR。因此目前 `llms-full.txt` 台股合計 89、tutor 合計 90，差 1 即為此缺口。

## 與 PR #174 的關係

#174（新增 `TaiwanStockMarginMaintenance`）同樣改到 `docs/llms-full.txt`、`docs/llms.txt`、`docs/tutor/TaiwanMarket/DataList.md` / `.en.md`，且都會動到本 PR 修改的同幾行數字，**會衝突**。

建議順序：**先合本 PR，再 rebase #174**。#174 rebase 後只需把數字各 +1（都落在籌碼面）：

| 位置 | 本 PR 合入後 | #174 應改為 |
|---|---|---|
| `llms-full.txt` `## Taiwan Market - Chip / Institutional` | 24 | 25 |
| `llms.txt` `### Taiwan Market (N datasets)` | 90 | 91 |
| `llms.txt` `Full list of N Taiwan datasets` | 90 | 91 |
| `tutor/TaiwanMarket/Chip.md` / `.en.md` | 25 | 26 |
| `tutor/TaiwanMarket/DataList.md` / `.en.md` | 90 | 91 |

## 驗證

以腳本對台股全部帶計數頁面重跑「宣稱值 vs 不重複 dataset 名稱數」，改後全部相等；中英文版每一組數字也全部一致。
