### PR TITLE
docs: taiwan_options_snapshot 補上臺指選擇權週五到期契約代碼 (TXU/TXV/TXX/TXY/TXZ)

### DIFF
--- a/docs/WhatIsNew.en.md
+++ b/docs/WhatIsNew.en.md
@@ -1,4 +1,6 @@
 #### 2026-08-09
+* [Taiwan Options Real-Time Information taiwan_options_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan-options-real-time-information-taiwan_options_snapshot-only-available-to-sponsor-members) now covers the **Friday-expiry** TAIEX option contracts: `data_id` accepts `TXU`, `TXV`, `TXX`, `TXY` and `TXZ` (expiring on the 1st ~ 5th Friday of the month). The existing `TXO` (monthly) and `TX1` ~ `TX5` (Wednesday-expiry) are unaffected
+    * A code returning no data in a given month is expected: the contract may not be listed yet, or that week does not exist in that month (e.g. a month with only 4 Fridays)
 * Added [Individual Stock Margin Maintenance TaiwanStockMarginMaintenance](https://finmind.github.io/en/tutor/TaiwanMarket/Chip/#individual-stock-margin-maintenance-taiwanstockmarginmaintenance-only-available-for-sponsor-members): data range 2001-01-05 ~ now (TPEx stocks from 2007-01-04). Provides the daily margin maintenance ratio (%), margin cost line, margin purchase balance (lots) and the margin purchase ratio applied, per stock. This dataset is an **estimated indicator** (public disclosure does not provide the margin purchase amount at the individual-stock level), so the numbers will not match other services — see the documentation for details
 
 #### 2026-08-08

--- a/docs/WhatIsNew.md
+++ b/docs/WhatIsNew.md
@@ -1,4 +1,6 @@
 #### 2026-08-09
+* [台股選擇權即時資訊 taiwan_options_snapshot](https://finmind.github.io/tutor/TaiwanMarket/RealTime/#taiwan_options_snapshot-sponsor) 增開臺指選擇權**週五到期**契約：`data_id` 新增 `TXU`、`TXV`、`TXX`、`TXY`、`TXZ`（當月第 1 ~ 5 個星期五到期）。原有的 `TXO`（月選）與 `TX1` ~ `TX5`（週三到期）不受影響
+    * 部分代碼在特定月份查無資料屬正常現象（契約尚未掛牌，或該月不存在對應週次，例如某月只有 4 個星期五）
 * 新增 [個股融資維持率 TaiwanStockMarginMaintenance](https://finmind.github.io/tutor/TaiwanMarket/Chip/#taiwanstockmarginmaintenance-sponsor)：資料區間 2001-01-05 ~ now（上櫃自 2007-01-04 起）。提供個股每日融資維持率(%)、融資成本線、融資餘額（張）與計算採用的融資成數；本資料集為**估算指標**（公開資訊未揭露個股層級的融資金額），與其他服務的數字不會一致，詳見文件說明
 
 #### 2026-08-08

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -752,6 +752,9 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 ### taiwan_options_snapshot (台股選擇權即時資訊)
 - Tier: Sponsor
 - Params: dataset=taiwan_options_snapshot, data_id=TXO (or empty for all)
+- data_id contract series: TXO = monthly; TX1, TX2, TX3, TX4, TX5 = weekly expiring on the 1st-5th Wednesday of the month; TXU, TXV, TXX, TXY, TXZ = weekly expiring on the 1st-5th Friday of the month
+- A series returns no rows when that contract is not listed yet, or when the month has no such week (e.g. no 5th Friday). This is expected, not missing data.
+- If a contract has not traded yet today, the row carries the price and volume from the last session in which it did trade; use the date field to tell whether a row is a same-day quote.
 - Columns: open, high, low, close, change_price, change_rate, average_price, volume, total_volume, amount, total_amount, yesterday_volume, buy_price, buy_volume, sell_price, sell_volume, volume_ratio, date, options_id, TickType
 
 ---

--- a/docs/tutor/TaiwanMarket/RealTime.en.md
+++ b/docs/tutor/TaiwanMarket/RealTime.en.md
@@ -1,10 +1,10 @@
 For Taiwan stock real-time data, we have 4 datasets, as listed below:
 
 
-- [Taiwan Stock Real-Time Information taiwan_stock_tick_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan_stock_tick_snapshot-sponsor)
+- [Taiwan Stock Real-Time Information taiwan_stock_tick_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan-stock-real-time-information-taiwan_stock_tick_snapshot-only-available-to-sponsor-members)
 - [Futures and Options Real-Time Quote Overview TaiwanFutOptTickInfo](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwanfutopttickinfo)
-- [Taiwan Futures Real-Time Information taiwan_futures_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan_futures_snapshot-sponsor)
-- [Taiwan Options Real-Time Information taiwan_options_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan_options_snapshot-sponsor)
+- [Taiwan Futures Real-Time Information taiwan_futures_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan-futures-real-time-information-taiwan_futures_snapshot-only-available-to-sponsor-members)
+- [Taiwan Options Real-Time Information taiwan_options_snapshot](https://finmind.github.io/en/tutor/TaiwanMarket/RealTime/#taiwan-options-real-time-information-taiwan_options_snapshot-only-available-to-sponsor-members)
 
 
 ----------------------------------
@@ -257,6 +257,19 @@ Currently supports real-time quotes for TAIEX futures and TAIEX options.
 #### Taiwan Options Real-Time Information taiwan_options_snapshot (only available to [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
 (updated approximately every 30 seconds)
 
+??? note "Contract series codes (monthly, Wednesday-expiry weekly, Friday-expiry weekly)"
+    TAIEX options come in three contract series. Pass the corresponding TAIFEX trading-system code as `data_id`:
+
+    | `data_id` | Contract |
+    | --- | --- |
+    | `TXO` | Monthly |
+    | `TX1` `TX2` `TX3` `TX4` `TX5` | Weekly, expiring on the 1st ~ 5th **Wednesday** of the month |
+    | `TXU` `TXV` `TXX` `TXY` `TXZ` | Weekly, expiring on the 1st ~ 5th **Friday** of the month |
+
+    Some codes return no data in a given month. This is expected behaviour, not missing data, for two reasons: the contract may not be listed yet (weekly contracts are listed only a limited period before expiry), or that week does not exist in that month (e.g. a month with only 4 Fridays has no 5th-Friday contract).
+
+    Also note that if a contract has not traded yet on the current day, the response carries the price and volume from the **last session in which it did trade**. Use the returned `date` field to tell whether a row is a same-day quote.
+
 !!! example
     === "Package"
         ```python
@@ -264,7 +277,8 @@ Currently supports real-time quotes for TAIEX futures and TAIEX options.
 
         api = DataLoader()
         api.login_by_token(api_token='token')
-        # Currently only TAIEX options are supported: TXO, TX1, TX2, TX3, TX4
+        # Currently only TAIEX options are supported
+        # Monthly TXO; Wednesday-expiry weekly TX1~TX5; Friday-expiry weekly TXU, TXV, TXX, TXY, TXZ
         df = api.taiwan_options_snapshot(options_id="TXO")
         ```
     === "Python-request"
@@ -275,7 +289,7 @@ Currently supports real-time quotes for TAIEX futures and TAIEX options.
         headers = {"Authorization": f"Bearer {token}"}
         url = "https://api.finmindtrade.com/api/v4/taiwan_options_snapshot"
         parameter = {
-            "data_id": "TXO", # TXO, TX1, TX2, TX3, TX4, TX5
+            "data_id": "TXO", # TXO(monthly), TX1~TX5(Wed-expiry), TXU/TXV/TXX/TXY/TXZ(Fri-expiry)
             # "data_id": "", # fetch all at once
         }
         resp = requests.get(url, headers=headers, params=parameter)
@@ -293,7 +307,7 @@ Currently supports real-time quotes for TAIEX futures and TAIEX options.
         response = httr::GET(
             url = url,
             query = list(
-                data_id="TXO" # TXO, TX1, TX2, TX3, TX4, TX5
+                data_id="TXO" # TXO(monthly), TX1~TX5(Wed-expiry), TXU/TXV/TXX/TXY/TXZ(Fri-expiry)
                 # data_id="" # fetch all at once
             ),
             add_headers(Authorization = paste("Bearer", token))

--- a/docs/tutor/TaiwanMarket/RealTime.md
+++ b/docs/tutor/TaiwanMarket/RealTime.md
@@ -257,6 +257,19 @@
 #### 台股選擇權即時資訊 taiwan_options_snapshot (只限 [sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) 會員使用)
 (約 30 秒更新一次)
 
+??? note "契約系列代碼（月選、週三到期週選、週五到期週選）"
+    臺指選擇權共有三組契約系列，`data_id` 請填入對應的期交所交易系統代碼：
+
+    | `data_id` | 契約 |
+    | --- | --- |
+    | `TXO` | 月選 |
+    | `TX1` `TX2` `TX3` `TX4` `TX5` | 週選，當月第 1 ~ 5 個**星期三**到期 |
+    | `TXU` `TXV` `TXX` `TXY` `TXZ` | 週選，當月第 1 ~ 5 個**星期五**到期 |
+
+    部分代碼在特定月份會查無資料，屬正常現象而非資料缺漏，原因有二：一是該契約尚未掛牌（週選於到期前一段期間才掛出），二是該月份不存在對應的週次（例如某月只有 4 個星期五，就不會有第 5 個星期五的契約）。
+
+    另外，若某契約當日尚無成交，回傳的會是該契約**最後一次有成交時**的價量。要判斷是否為當日即時報價，請以回傳的 `date` 欄位為準。
+
 !!! example
     === "Package"
         ```python
@@ -264,7 +277,8 @@
 
         api = DataLoader()
         api.login_by_token(api_token='token')
-        # 目前只支援台指選擇權, TXO, TX1, TX2, TX3, TX4
+        # 目前只支援台指選擇權
+        # 月選 TXO；週三到期週選 TX1~TX5；週五到期週選 TXU, TXV, TXX, TXY, TXZ
         df = api.taiwan_options_snapshot(options_id="TXO")
         ```
     === "Python-request"
@@ -275,7 +289,7 @@
         headers = {"Authorization": f"Bearer {token}"}
         url = "https://api.finmindtrade.com/api/v4/taiwan_options_snapshot"
         parameter = {
-            "data_id": "TXO", # TXO, TX1, TX2, TX3, TX4, TX5
+            "data_id": "TXO", # TXO(月選), TX1~TX5(週三到期), TXU/TXV/TXX/TXY/TXZ(週五到期)
             # "data_id": "", # 一次全部
         }
         resp = requests.get(url, headers=headers, params=parameter)
@@ -293,7 +307,7 @@
         response = httr::GET(
             url = url,
             query = list(
-                data_id="TXO" # TXO, TX1, TX2, TX3, TX4, TX5
+                data_id="TXO" # TXO(月選), TX1~TX5(週三到期), TXU/TXV/TXX/TXY/TXZ(週五到期)
                 # data_id="" # 一次全部
             ),
             add_headers(Authorization = paste("Bearer", token))


### PR DESCRIPTION
對應 [FinMind/FinMind#441](https://github.com/FinMind/FinMind/issues/441)。`taiwan_options_snapshot` 已增開臺指選擇權**週五到期**系列並上線驗證通過，文件同步更新。

## 背景

原本文件只列出 `TXO`（月選）與 `TX1~TX5`（週三到期週選）。期交所 2025-06-27 起加掛的週五到期系列（`TXU/TXV/TXX/TXY/TXZ`＝當月第 1~5 個星期五）現已支援，文件需補上，否則使用者不會知道可以查。

## 改了什麼

### `docs/tutor/TaiwanMarket/RealTime.md` / `RealTime.en.md`

- 「台股選擇權即時資訊」章節新增 `??? note` 摺疊區塊，用表格列出三組契約系列
- 補充兩件使用者一定會踩到的事：
  - **部分代碼查無資料屬正常**——契約尚未掛牌，或該月不存在對應週次（例如某月只有 4 個星期五，就沒有第 5 個星期五契約）
  - **契約當日尚無成交時，回傳的是最後一次有成交時的價量**，要判斷是否為當日報價請看 `date` 欄位。這是 snapshot 一直以來的行為，並非週五系列特有
- Package / Python-request / R 三個 tab 的 `data_id` 註解一併補上週五系列

### 順手修的既有問題（請一併確認）

1. **Package tab 的代碼清單漏了 `TX5`**（原本只寫到 `TX4`），中英文版皆是。
2. **`RealTime.en.md` 頁首 3 條死連結**。英文頁的 anchor 是「完整標題 slug」，原本沿用中文頁的短 anchor（`#taiwan_options_snapshot-sponsor` 這類）全部跳不到。已改成實際 slug，例如：
   `#taiwan-options-real-time-information-taiwan_options_snapshot-only-available-to-sponsor-members`
   （是拿 `mkdocs build` 產出的 HTML 比對 `id=` 確認的，不是猜的。）

### `docs/llms-full.txt`

`taiwan_options_snapshot` 段落補三行純文字說明（契約系列對照、查無資料的兩種正常情形、未成交時的回傳語意），維持純文字格式不加 markdown 結構。

### `docs/WhatIsNew.md` / `WhatIsNew.en.md`

2026-08-09 新增一則更新日誌。

## 驗證

- `mkdocs build` 中英文皆建置成功
- `??? note` 內的表格確認正確渲染成 `<table>`（3 列資料），不是被當成純文字
- 中文頁 anchor `#taiwan_options_snapshot-sponsor` 經建置後 HTML 確認存在

## 已知、未處理

`docs/WhatIsNew.en.md:56` 另有一條同類型的英文 anchor 死連結（2025 年的歷史更新日誌條目）。不屬本次範圍，沒有一併改，避免動到歷史 changelog。若要一起清，可以另開一個 PR 掃全 repo 的英文 anchor。