### PR TITLE
docs(TaiwanStockPER): 補上「一次拿特定日期，所有資料」章節

### DIFF
--- a/docs/tutor/TaiwanMarket/Technical.en.md
+++ b/docs/tutor/TaiwanMarket/Technical.en.md
@@ -1375,6 +1375,78 @@ In Taiwan stock technical data, we have 20 datasets, as follows:
         }
         ```
 
+#### Fetch all data for a specific date at once (available only to [backer, sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) members)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_per_pbr(
+            start_date='2020-04-06',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # Refer to login to obtain the token
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPER",
+            "start_date": "2020-04-06",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # Refer to login to obtain the token
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPER",
+                start_date= "2020-04-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   dividend_yield |   PER |   PBR |
+        |---:|:-----------|-----------:|-----------------:|------:|------:|
+        |  0 | 2020-04-06 |       1101 |             7.68 |  9.12 |  1.14 |
+        |  1 | 2020-04-06 |       1102 |             7.68 |  7.52 |  0.90 |
+        |  2 | 2020-04-06 |       1103 |             6.60 |  7.54 |  0.43 |
+        |  3 | 2020-04-06 |       1104 |             6.33 |  9.08 |  0.57 |
+        |  4 | 2020-04-06 |       1108 |             2.18 | 62.64 |  0.65 |
+    === "Schema"
+        ```
+        {
+            date: str, # date
+            stock_id: str, # stock code
+            dividend_yield: float64, # dividend yield
+            PER: float64, # price-to-earnings ratio
+            PBR: float64 # price-to-book ratio
+        }
+        ```
+
 ----------------------------------
 #### Order and Trade Statistics Every 5 Seconds TaiwanStockStatisticsOfOrderBookAndTrade
 (Due to the large data volume, each request only provides one day's data.)

--- a/docs/tutor/TaiwanMarket/Technical.md
+++ b/docs/tutor/TaiwanMarket/Technical.md
@@ -1375,6 +1375,78 @@
         }
         ```
 
+#### 一次拿特定日期，所有資料(只限 [backer、sponsor](https://finmindtrade.com/analysis/#/Sponsor/sponsor) 會員使用)
+
+!!! example
+    === "Package"
+        ```python
+        from FinMind.data import DataLoader
+
+        api = DataLoader()
+        # api.login_by_token(api_token='token')
+        df = api.taiwan_stock_per_pbr(
+            start_date='2020-04-06',
+        )
+        ```
+    === "Python-request"
+        ```python
+        import requests
+        import pandas as pd
+        url = "https://api.finmindtrade.com/api/v4/data"
+        token = "" # 參考登入，獲取金鑰
+        headers = {"Authorization": f"Bearer {token}"}
+        parameter = {
+            "dataset": "TaiwanStockPER",
+            "start_date": "2020-04-06",
+        }
+        data = requests.get(url, headers=headers, params=parameter)
+        data = data.json()
+        data = pd.DataFrame(data['data'])
+        print(data.head())
+        ```
+    === "R"
+        ```R
+        library(httr)
+        library(data.table)
+        library(dplyr)
+        url = 'https://api.finmindtrade.com/api/v4/data'
+        token = "" # 參考登入，獲取金鑰
+        response = httr::GET(
+            url = url,
+            query = list(
+                dataset="TaiwanStockPER",
+                start_date= "2020-04-06"
+            ),
+            add_headers(Authorization = paste("Bearer", token))
+        )
+        data = content(response)
+        df = data$data %>%
+        do.call('rbind',.) %>%
+        data.table
+        head(df)
+
+        ```
+
+!!! output
+    === "DataFrame"
+        |    | date       |   stock_id |   dividend_yield |   PER |   PBR |
+        |---:|:-----------|-----------:|-----------------:|------:|------:|
+        |  0 | 2020-04-06 |       1101 |             7.68 |  9.12 |  1.14 |
+        |  1 | 2020-04-06 |       1102 |             7.68 |  7.52 |  0.90 |
+        |  2 | 2020-04-06 |       1103 |             6.60 |  7.54 |  0.43 |
+        |  3 | 2020-04-06 |       1104 |             6.33 |  9.08 |  0.57 |
+        |  4 | 2020-04-06 |       1108 |             2.18 | 62.64 |  0.65 |
+    === "Schema"
+        ```
+        {
+            date: str, # 日期
+            stock_id: str, # 股票代碼
+            dividend_yield: float64, # 殖利率
+            PER: float64, # 本益比
+            PBR: float64 # 股價淨值比
+        }
+        ```
+
 ----------------------------------
 #### 每5秒委託成交統計 TaiwanStockStatisticsOfOrderBookAndTrade
 (由於資料量過大，單次請求只提供一天資料)


### PR DESCRIPTION
## 問題

`TaiwanStockPER` 在 tutor 文件裡缺少「一次拿特定日期，所有資料」的章節，
但 API 其實支援不帶 `data_id`、一次取得某日全市場 PER/PBR
（`api` repo 的 `WITHOUT_DATA_ID_CHECK_DICT` 對本 dataset 取預設值 `True`，
`check_with_data_id()` 只擋 `user_level < 2`，所以 backer / sponsor 可用）。

實際驗證（`start_date=2020-04-06`，未帶 `data_id`）回傳全市場資料：

```
{"msg":"success","status":200,"data":[{"date":"2020-04-06","stock_id":"1101","dividend_yield":7.68,"PER":9.12,"PBR":1.14}, ...]}
```

## 修改

- `docs/tutor/TaiwanMarket/Technical.md`：在 TaiwanStockPER 章節後新增
  「一次拿特定日期，所有資料(只限 backer、sponsor 會員使用)」，
  格式對齊既有的 TaiwanStockDayTrading / TaiwanStockPriceLimit 章節
  （Package / Python-request / R 三種範例 + DataFrame / Schema 輸出）。
- `docs/tutor/TaiwanMarket/Technical.en.md`：同步新增英文版章節。

範例輸出取自實際 API 回應，非杜撰。

🤖 Generated with [Claude Code](https://claude.com/claude-code)