### PR TITLE
docs: 說明 TaiwanStockMonthRevenue create_time 的語意與起始日

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -548,6 +548,7 @@ Async batch query is supported by datasets that require `data_id` parameter. Not
 - Params: dataset=TaiwanStockMonthRevenue, data_id=2330, start_date=2019-03-31
 - Params (all stocks, Backer/Sponsor): dataset=TaiwanStockMonthRevenue, start_date=2019-03-31 (不帶 data_id，取得該日所有股票資料)
 - Columns: date (str), stock_id (str), country (str), revenue (int64), revenue_month (int64), revenue_year (int64), create_time (str, 建立時間 YYYY-MM-DD; empty for older historical rows)
+- Known limitation: create_time has only been recorded since 2026-04-21 (empty string before that), and it is the date the row entered the FinMind database, not the company's official announcement time; FinMind collects monthly revenue several times a day, so the gap should be negligible. Rows written on 2026-04-21 all carry create_time=2026-04-21 as the column's initial value.
 
 ### TaiwanStockCapitalReductionReferencePrice (減資恢復買賣參考價格)
 - Tier: Free

--- a/docs/tutor/TaiwanMarket/Fundamental.en.md
+++ b/docs/tutor/TaiwanMarket/Fundamental.en.md
@@ -935,6 +935,13 @@ In Taiwan stock fundamental data, we have 12 datasets, as follows:
 - Data range: 2002-02-01 ~ now
 - Coverage: listed (TWSE), OTC (TPEx) and emerging market companies, distinguished by `stock_id` (use `TaiwanStockInfo` to look up market type)
 
+??? note "`create_time` only exists from 2026-04-21 onwards, and reflects when the row entered the FinMind database"
+    `create_time` is the date (YYYY-MM-DD) on which the monthly revenue row **entered the FinMind database**. It has only been recorded since **2026-04-21**; rows older than that carry **no** `create_time` and the field is an empty string.
+
+    It is therefore **not the official announcement time** filed by the company on the Market Observation Post System - it only tells you when FinMind observed the row. That said, FinMind collects monthly revenue several times a day, so in practice the gap to the announcement time should be negligible, and the field can still be used as an approximation of "roughly when this revenue figure was published".
+
+    Note also that rows written on 2026-04-21 (the day the column went live) all carry `create_time` = 2026-04-21, which is the initial backfilled value of the column rather than the day those figures were announced.
+
 !!! example
     === "Package"
         ```python
@@ -1027,7 +1034,7 @@ In Taiwan stock fundamental data, we have 12 datasets, as follows:
             revenue: int64, # revenue
             revenue_month: int64, # revenue month
             revenue_year: int64, # revenue year
-            create_time: str # creation time (YYYY-MM-DD); empty string for older historical rows
+            create_time: str # creation time (YYYY-MM-DD); recorded only since 2026-04-21, empty string for older historical rows
         }
         ```
 
@@ -1102,7 +1109,7 @@ In Taiwan stock fundamental data, we have 12 datasets, as follows:
             revenue: int64, # revenue
             revenue_month: int64, # revenue month
             revenue_year: int64, # revenue year
-            create_time: str # creation time (YYYY-MM-DD); empty string for older historical rows
+            create_time: str # creation time (YYYY-MM-DD); recorded only since 2026-04-21, empty string for older historical rows
         }
         ```
 ----------------------------------

--- a/docs/tutor/TaiwanMarket/Fundamental.md
+++ b/docs/tutor/TaiwanMarket/Fundamental.md
@@ -935,6 +935,13 @@
 - 資料區間：2002-02-01 ~ now
 - 資料涵蓋：上市、上櫃、興櫃公司，以 `stock_id` 區分（可搭配 `TaiwanStockInfo` 查詢市場別）
 
+??? note "`create_time` 自 2026-04-21 起才有值，且代表進入 FinMind 資料庫的時間"
+    `create_time` 是**該筆月營收進入 FinMind 資料庫的日期**（YYYY-MM-DD），自 **2026-04-21** 起才開始記錄，在此之前的歷史資料**沒有** `create_time`，該欄位為空字串。
+
+    因此它**不等於公司在公開資訊觀測站的正式公告時間**，僅能視為 FinMind 觀察到該筆資料的時間。不過 FinMind 一天內會多次收集月營收資料，理論上與公告時間不會有明顯差距，仍可作為「這筆營收大約何時公布」的近似參考。
+
+    另外，2026-04-21（欄位啟用當天）寫入的列，`create_time` 一律為 2026-04-21，是欄位啟用時的初始值，不代表那幾筆營收是在該日公告。
+
 !!! example
     === "Package"
         ```python
@@ -1027,7 +1034,7 @@
             revenue: int64, # 營收
             revenue_month: int64, # 營收月份
             revenue_year: int64, # 營收年份
-            create_time: str # 建立時間 (YYYY-MM-DD)，舊歷史資料為空字串
+            create_time: str # 建立時間 (YYYY-MM-DD)，2026-04-21 起才記錄，舊歷史資料為空字串
         }
         ```
 
@@ -1102,7 +1109,7 @@
             revenue: int64, # 營收
             revenue_month: int64, # 營收月份
             revenue_year: int64, # 營收年份
-            create_time: str # 建立時間 (YYYY-MM-DD)，舊歷史資料為空字串
+            create_time: str # 建立時間 (YYYY-MM-DD)，2026-04-21 起才記錄，舊歷史資料為空字串
         }
         ```
 ----------------------------------


### PR DESCRIPTION
## 背景

客戶容易把月營收表的 `create_time` 當成公司在公開資訊觀測站的正式公告時間。實際上這欄位有兩個需要說明的限制。

## 修改內容

在 `月營收表 TaiwanStockMonthRevenue` 一節新增 `??? note` 摺疊說明（zh / en 各一），並同步 schema 註解與 `llms-full.txt`：

1. `create_time` **自 2026-04-21 起才開始記錄**，在此之前的歷史資料沒有 `create_time`，該欄位為空字串。
2. 它是**該筆資料進入 FinMind 資料庫的日期**，不等於正式公告時間；但 FinMind 一天內會多次收集月營收，理論上與公告時間不會有明顯差距，仍可作為近似參考。
3. 2026-04-21（欄位啟用當天）寫入的列 `create_time` 一律為 2026-04-21，是初始值，不代表那幾筆營收在該日公告。

### 檔案

- `docs/tutor/TaiwanMarket/Fundamental.md` — `??? note` + schema 註解（2 處）
- `docs/tutor/TaiwanMarket/Fundamental.en.md` — 同上英文版
- `docs/llms-full.txt` — 新增 `- Known limitation:` 條目（純文字，無 admonition）

## 驗證

實際打 FinMind API 查 2330 的 2026 年資料：

| date | create_time |
|---|---|
| 2026-01-01 | (空字串) |
| 2026-02-01 | (空字串) |
| 2026-03-01 | 2026-04-21 |
| 2026-04-01 | 2026-04-21 |
| 2026-05-01 | 2026-05-08 |
| 2026-06-01 | 2026-06-10 |
| 2026-07-01 | 2026-07-13 |
| 2026-08-01 | 2026-08-10 |

vueWeb 對應 MR：https://gitlab.com/finmind/web/vueweb/-/merge_requests/186

🤖 Generated with [Claude Code](https://claude.com/claude-code)